### PR TITLE
feat: add ApplicativeError and MonadError type classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ inspired by Haskell's standard library and by
   a type class that extends `Functor` and `Apply`, exposing `pure` 
   and that obeys the laws defined in 
   [ApplicativeLaws](https://funfix.org/api/classes/_types_applicative_.applicativelaws.html)
+- **[ApplicativeError](https://funfix.org/api/classes/_types_applicative_.applicativeerror.html)**:
+  a type class that extends `Applicative`, for applicative types that can raise errors 
+  or recover from them and that obeys the laws defined in
+  [ApplicativeErrorLaws](https://funfix.org/api/classes/_types_applicative_.applicativeerrorlaws.html)
 - **[FlatMap](https://funfix.org/api/classes/_types_monad_.flatmap.html)**:
   a type class that extends `Functor` and `Apply`, exposing `flatMap` 
   and `tailRecM` and that obeys the laws defined in 
@@ -81,6 +85,10 @@ inspired by Haskell's standard library and by
   a type class that extends `Applicative` and `FlatMap`
   and that obeys the laws defined in 
   [MonadLaws](https://funfix.org/api/classes/_types_monad_.monadlaws.html)
+- **[MonadError](https://funfix.org/api/classes/_types_monad_.monaderror.html)**:
+  a type class that extends `ApplicativeError` and `Monad`, for monads that 
+  can raise or recover from errors and that obeys the laws defined in 
+  [MonadErrorLaws](https://funfix.org/api/classes/_types_monad_.monaderrorlaws.html)
     
 More is coming 😉
 

--- a/rootdoc.md
+++ b/rootdoc.md
@@ -103,11 +103,17 @@ inspired by Haskell's standard library and by
 - **[[Applicative]]**: a type class that extends [[Functor]] and [[Apply]], 
   that exposes [pure]{@link Applicative.pure} and that obeys the laws 
   defined in [[ApplicativeLaws]]
+- **[[ApplicativeError]]**: a type class that extends [[Applicative]],
+  for applicative types that can raise errors or recover from them
+  and that obeys the laws defined in [[ApplicativeErrorLaws]]
 - **[[FlatMap]]**: a type class that extends [[Functor]] and [[Apply]], 
   that exposes [flatMap]{@link FlatMap.flatMap} and
   [tailRecM]{@link FlatMap.tailRecM} and that obeys the laws 
   defined in [[FlatMapLaws]]
 - **[[Monad]]**: a type class that extends [[Applicative]] and [[FlatMap]]
   and that obeys the laws defined in [[MonadLaws]]
+- **[[MonadError]]**: a type class that extends [[ApplicativeError]] 
+  and [[Monad]], for monads that can raise or recover from errors
+  and that obeys the laws defined in [[MonadErrorLaws]]
   
 More is coming 😉

--- a/src/core/disjunctions.ts
+++ b/src/core/disjunctions.ts
@@ -1117,7 +1117,7 @@ export const None: Option<never> =
  * value, wrapped in the [[Success]] type for it to be further operated upon
  * by the next combinator in the chain, or the exception wrapped in the
  * [[Failure]] type usually to be simply passed on down the chain.
- * Combinators such as `handleError` and `handleErrorWith` are designed to provide
+ * Combinators such as `recover` and `recoverWith` are designed to provide
  * some type of global behavior in the case of failure.
  *
  * NOTE: all `Try` combinators will catch exceptions and return failure

--- a/src/effect/eval.js.flow
+++ b/src/effect/eval.js.flow
@@ -34,6 +34,7 @@ declare export class Eval<+A> {
 
   recover<AA>(f: (e: any) => AA): Eval<A | AA>;
   recoverWith<AA>(f: (e: any) => Eval<AA>): Eval<A | AA>;
+  attempt(): Eval<Either<any, A>>;
 
   memoize(): Eval<A>;
   memoizeOnSuccess(): Eval<A>;

--- a/src/effect/eval.ts
+++ b/src/effect/eval.ts
@@ -269,6 +269,18 @@ export class Eval<A> {
   }
 
   /**
+   * Handle errors by turning them into {@link Either} values.
+   *
+   * If there is no error, then a `Right` value will be returned instead.
+   * Errors can be handled by this method.
+   */
+  attempt(): Eval<Either<any, A>> {
+    return this.transform(
+      _ => Either.left<any, A>(_),
+      Either.right)
+  }
+
+  /**
    * Memoizes (caches) the result of the source on the first
    * evaluation and reuses it on subsequent invocations of `get()`.
    *

--- a/src/types/applicative.js.flow
+++ b/src/types/applicative.js.flow
@@ -20,6 +20,7 @@
 import type { Constructor } from "./kinds"
 import { HK, Equiv } from "./kinds"
 import { Functor, FunctorLaws } from "./functor"
+import { Either } from "../core/disjunctions"
 
 export interface Apply<F> extends Functor<F> {
   ap<A, B>(fa: HK<F, A>, ff: HK<F, (a: A) => B>): HK<F, B>;
@@ -66,3 +67,29 @@ export interface ApplicativeLaws<F> extends ApplyLaws<F> {
 
 declare export function applicativeOf<F>(c: Constructor<F>): Applicative<F>;
 declare export function applicativeLawsOf<F>(instance: Applicative<F>): ApplicativeLaws<F>;
+
+export interface ApplicativeError<F, E> extends Applicative<F> {
+  raise<A>(e: E): HK<F, A>;
+  recoverWith<A>(fa: HK<F, A>, f: (e: E) => HK<F, A>): HK<F, A>;
+  recover<A>(fa: HK<F, A>, f: (e: E) => A): HK<F, A>;
+  attempt<A>(fa: HK<F, A>): HK<F, Either<E, A>>;
+
+  // Implements TypeClass<F>
+  static +_funTypeId: string;
+  static +_funSupertypeIds: string[];
+  static +_funErasure: ApplicativeError<any, any>;
+}
+
+export interface ApplicativeErrorLaws<F, E> extends ApplicativeLaws<F> {
+  +F: ApplicativeError<F, E>;
+
+  applicativeErrorRecoverWith<A>(e: E, f: (e: E) => HK<F, A>): Equiv<HK<F, A>>;
+  applicativeErrorRecover<A>(e: E, f: (e: E) => A): Equiv<HK<F, A>>;
+  recoverWithPure<A>(a: A, f: (e: E) => HK<F, A>): Equiv<HK<F, A>>;
+  recoverPure<A>(a: A, f: (e: E) => A): Equiv<HK<F, A>>;
+  raiseErrorAttempt(e: E): Equiv<HK<F, Either<E, void>>>;
+  pureAttempt<A>(a: A): Equiv<HK<F, Either<E, A>>>;
+}
+
+declare export function applicativeErrorOf<F, E>(c: Constructor<F>): ApplicativeError<F, E>;
+declare export function applicativeErrorLawsOf<F, E>(instance: ApplicativeError<F, E>): ApplicativeErrorLaws<F, E>;

--- a/src/types/applicative.ts
+++ b/src/types/applicative.ts
@@ -348,7 +348,7 @@ export function applyLawsOf<F>(instance: Apply<F>): ApplyLaws<F> {
  * // Registering global Applicative instance for Box, needed in order
  * // for the `functorOf(Box)`, `applyOf(Box)` and `applicativeOf(Box)`
  * // calls to work
- * registerTypeClassInstance(Applicative)(Box, new BoxFunctor())
+ * registerTypeClassInstance(Applicative)(Box, new BoxApplicative())
  * ```
  *
  * We are using `implements` in order to support multiple inheritance and to
@@ -516,7 +516,6 @@ export function applicativeLawsOf<F>(instance: Applicative<F>): ApplicativeLaws<
   return new (class extends ApplicativeLaws<F> { public readonly F = instance })()
 }
 
-// ----
 /**
  * The `ApplicativeError` type class is a {@link Applicative} that
  * also allows you to raise and or handle an error value.
@@ -525,6 +524,90 @@ export function applicativeLawsOf<F>(instance: Applicative<F>): ApplicativeLaws<
  * applicative types.
  *
  * MUST follow the law defined in {@link ApplicativeErrorLaws}.
+ *
+ * ## Implementation notes
+ *
+ * Even though in TypeScript the Funfix library is using `abstract class` to
+ * express type classes, when implementing this type class it is recommended
+ * that you implement it as a mixin using "`implements`", instead of extending
+ * it directly with "`extends`". See
+ * [TypeScript: Mixins]{@link https://www.typescriptlang.org/docs/handbook/mixins.html}
+ * for details and note that we already have {@link applyMixins} defined.
+ *
+ * Implementation example:
+ *
+ * ```typescript
+ * import {
+ *   HK,
+ *   ApplicativeError,
+ *   registerTypeClassInstance,
+ *   applyMixins,
+ *   Try
+ * } from "funfix"
+ *
+ * // Type alias defined for readability.
+ * // HK is our encoding for higher-kinded types.
+ * type BoxK<T> = HK<Box<any>, T>
+ *
+ * class Box<T> implements HK<Box<any>, T> {
+ *   constructor(public value: Try<T>) {}
+ *
+ *   // Implements HK<Box<any>, A>, not really needed, but useful in order
+ *   // to avoid type casts. Note they can and should be undefined:
+ *   readonly _funKindF: Box<any>
+ *   readonly _funKindA: T
+ * }
+ *
+ * class BoxApplicativeError implements ApplicativeError<Box<any>, any> {
+ *   pure<A>(a: A): Box<A> { return new Box(Try.success(a)) }
+ *
+ *   ap<A, B>(fa: BoxK<A>, ff: BoxK<(a: A) => B>): Box<B> {
+ *     const ta = (fa as Box<A>).value
+ *     const tf = (ff as Box<(a: A) => B>).value
+ *     return new Box(Try.map2(ta, tf, (a, f) => f(a)))
+ *   }
+ *
+ *   raise<A>(e: any): HK<Box<any>, A> {
+ *     return new Box(Try.failure(e))
+ *   }
+ *
+ *   recoverWith<A>(fa: BoxK<A>, f: (e: any) => BoxK<A>): HK<Box<any>, A> {
+ *     return new Box((fa as Box<A>).value.recoverWith(e => (f(e) as Box<A>).value))
+ *   }
+ *
+ *   // Mixed-in, as these have default implementations
+ *   map: <A, B>(fa: BoxK<A>, f: (a: A) => B) => Box<B>
+ *   map2: <A, B, Z>(fa: BoxK<A>, fb: BoxK<B>, f: (a: A, b: B) => Z) => Box<Z>
+ *   product: <A, B> (fa: BoxK<A>, fb: BoxK<B>) => Box<[A, B]>
+ *   unit: () => Box<void>
+ *   recover: <A>(fa: HK<Box<any>, A>, f: (e: any) => A) => HK<Box<any>, A>
+ *   attempt: <A>(fa: HK<Box<any>, A>) => HK<Box<any>, Either<any, A>>
+ * }
+ *
+ * // Call needed in order to implement `map`, `map2`, `product`, etc.
+ * // using the default implementations defined by `ApplicativeError`,
+ * // because we are using `implements` instead of `extends` above and
+ * // because in this sample we want the default implementations,
+ * // but note that you can always provide your own
+ * applyMixins(BoxApplicativeError, [ApplicativeError])
+ *
+ * // Registering global ApplicativeError instance for Box, needed in order
+ * // for the `functorOf(Box)`, `applyOf(Box)`, `applicativeOf(Box)`
+ * // and `applicativeErrorOf(Box)` calls to work
+ * registerTypeClassInstance(ApplicativeError)(Box, new BoxApplicativeError())
+ * ```
+ *
+ * We are using `implements` in order to support multiple inheritance and to
+ * avoid inheriting any `static` members. In the Flow definitions (e.g.
+ * `.js.flow` files) for Funfix these type classes are defined with
+ * "`interface`", as they are meant to be interfaces that sometimes have
+ * default implementations and not classes.
+ *
+ * ## Credits
+ *
+ * This type class is inspired by the equivalent in Haskell's
+ * standard library and the implementation is inspired by the
+ * [Typelevel Cats]{@link http://typelevel.org/cats/} project.
  */
 export abstract class ApplicativeError<F, E> implements Applicative<F> {
   /**
@@ -547,12 +630,15 @@ export abstract class ApplicativeError<F, E> implements Applicative<F> {
    * @see {@link recoverWith} to map to an `F[A]` value instead of
    * simply an `A` value.
    */
-  abstract recover<A>(fa: HK<F, A>, f: (e: E) => A): HK<F, A>
+  recover<A>(fa: HK<F, A>, f: (e: E) => A): HK<F, A> {
+    const F = this
+    return F.recoverWith(fa, e => F.pure(f(e)))
+  }
 
   /**
    * Handle errors by turning them into {@link Either} values.
    *
-   * If there is no error, then `Right` value will be returned instead.
+   * If there is no error, then a `Right` value will be returned.
    * All non-fatal errors should be handled by this method.
    */
   attempt<A>(fa: HK<F, A>): HK<F, Either<E, A>> {
@@ -570,7 +656,7 @@ export abstract class ApplicativeError<F, E> implements Applicative<F> {
 
   /** Mixed-in from {@link Applicative.unit}. */
   unit: () => HK<F, void>
-  /** Mixed-in from {@link Functor.unit}. */
+  /** Mixed-in from {@link Applicative.map}. */
   map: <A, B>(fa: HK<F, A>, f: (a: A) => B) => HK<F, B>
   /** Mixed-in from {@link Apply.map2}. */
   map2: <A, B, Z>(fa: HK<F, A>, fb: HK<F, B>, f: (a: A, b: B) => Z) => HK<F, Z>
@@ -587,6 +673,28 @@ export abstract class ApplicativeError<F, E> implements Applicative<F> {
   static readonly _funErasure: ApplicativeError<any, any>
 }
 
+applyMixins(ApplicativeError, [Applicative])
+
+/**
+ * Type class laws defined for {@link ApplicativeError}.
+ *
+ * This is an abstract definition. In order to use it in unit testing,
+ * the implementor must think of a strategy to evaluate the truthiness
+ * of the returned `Equiv` values.
+ *
+ * Even though in TypeScript the Funfix library is using classes to
+ * express these laws, when implementing this class it is recommended
+ * that you implement it as a mixin using `implements`, instead of extending
+ * it directly with `extends`. See
+ * [TypeScript: Mixins]{@link https://www.typescriptlang.org/docs/handbook/mixins.html}
+ * for details and note that we already have {@link applyMixins} defined.
+ *
+ * We are doing this in order to support multiple inheritance and to
+ * avoid inheriting any `static` members. In the Flow definitions (e.g.
+ * `.js.flow` files) for Funfix these classes are defined with
+ * `interface`, as they are meant to be interfaces that sometimes have
+ * default implementations and not classes.
+ */
 export abstract class ApplicativeErrorLaws<F, E> implements ApplicativeLaws<F> {
   /**
    * The {@link Applicative} designated instance for `F`,
@@ -596,12 +704,12 @@ export abstract class ApplicativeErrorLaws<F, E> implements ApplicativeLaws<F> {
 
   applicativeErrorRecoverWith<A>(e: E, f: (e: E) => HK<F, A>): Equiv<HK<F, A>> {
     const F = this.F
-    return Equiv.of(F.recoverWith(F.raise(e), f), f(e))
+    return Equiv.of(F.recoverWith(F.raise<A>(e), f), f(e))
   }
 
   applicativeErrorRecover<A>(e: E, f: (e: E) => A): Equiv<HK<F, A>> {
     const F = this.F
-    return Equiv.of(F.recover(F.raise(e), f), F.pure(f(e)))
+    return Equiv.of(F.recover(F.raise<A>(e), f), F.pure(f(e)))
   }
 
   recoverWithPure<A>(a: A, f: (e: E) => HK<F, A>): Equiv<HK<F, A>> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,9 +25,11 @@
  * - [types/functor]{@link "types/functor"}: exposes the {@link Functor}
  *   type class
  * - [types/applicative]{@link "types/applicative"}: exposes the
- *   {@link Apply} and {@link Applicative} type classes
+ *   {@link Apply}, {@link Applicative} and {@link ApplicativeError}
+ *   type classes
  * - [types/monad]{@link "types/monad"}: exposes the
- *   {@link FlatMap} and {@link Monad} type classes
+ *   {@link FlatMap}, {@link Monad} and {@link MonadError}
+ *   type classes
  *
  * À la carte imports work, assuming an ECMAScript 2015 compatible environment,
  * including ES2015 modules and `import` syntax:

--- a/src/types/instances.js.flow
+++ b/src/types/instances.js.flow
@@ -57,6 +57,10 @@ declare export class TryInstances {
   followedByL<A, B>(fa: TryK<A>, fb: () => TryK<B>): Try<B>;
   forEffect<A, B>(fa: TryK<A>, fb: TryK<B>): Try<A>;
   forEffectL<A, B>(fa: TryK<A>, fb: () => TryK<B>): Try<A>;
+  raise<A>(e: any): Eval<A>;
+  attempt<A>(fa: EvalK<A>): Eval<Either<any, A>>;
+  recoverWith<A>(fa: EvalK<A>, f: (e: any) => EvalK<A>): Eval<A>;
+  recover<A>(fa: EvalK<A>, f: (e: any) => A): Eval<A>;
 
   static global: TryInstances;
 }
@@ -96,6 +100,10 @@ declare export class EvalInstances {
   followedByL<A, B>(fa: EvalK<A>, fb: () => EvalK<B>): Eval<B>;
   forEffect<A, B>(fa: EvalK<A>, fb: EvalK<B>): Eval<A>;
   forEffectL<A, B>(fa: EvalK<A>, fb: () => EvalK<B>): Eval<A>;
+  raise<A>(e: any): Eval<A>;
+  attempt<A>(fa: EvalK<A>): Eval<Either<any, A>>;
+  recoverWith<A>(fa: EvalK<A>, f: (e: any) => EvalK<A>): Eval<A>;
+  recover<A>(fa: EvalK<A>, f: (e: any) => A): Eval<A>;
 
   static global: EvalInstances;
 }

--- a/src/types/monad.js.flow
+++ b/src/types/monad.js.flow
@@ -19,8 +19,12 @@
 
 import type { Constructor } from "./kinds"
 import { HK, Equiv } from "./kinds"
-import { Apply, ApplyLaws, Applicative, ApplicativeLaws } from "./applicative"
 import { Either } from "../core/disjunctions"
+import {
+  Apply, ApplyLaws,
+  Applicative, ApplicativeLaws,
+  ApplicativeError, ApplicativeErrorLaws
+} from "./applicative"
 
 export interface FlatMap<F> extends Apply<F>{
   flatMap<A, B>(fa: HK<F, A>, f: (a: A) => HK<F, B>): HK<F, B>;
@@ -69,3 +73,19 @@ export interface MonadLaws<F> extends ApplicativeLaws<F>, FlatMapLaws<F> {
 
 declare export function monadOf<F>(c: Constructor<F>): Monad<F>;
 declare export function monadLawsOf<F>(instance: Monad<F>): MonadLaws<F>;
+
+export interface MonadError<F, E> extends ApplicativeError<F, E>, Monad<F> {
+  // Implements TypeClass<F>
+  static +_funTypeId: string;
+  static +_funSupertypeIds: string[];
+  static +_funErasure: MonadError<any, any>;
+}
+
+export interface MonadErrorLaws<F, E> extends ApplicativeErrorLaws<F, E>, MonadLaws<F> {
+  +F: MonadError<F, E>;
+
+  monadErrorLeftZero<A, B>(e: E, f: (a: A) => HK<F, B>): Equiv<HK<F, B>>;
+}
+
+declare export function monadErrorOf<F, E>(c: Constructor<F>): MonadError<F, E>;
+declare export function monadErrorLawsOf<F, E>(instance: MonadError<F, E>): MonadErrorLaws<F, E>;

--- a/src/types/monad.ts
+++ b/src/types/monad.ts
@@ -667,3 +667,5 @@ export const monadOf: <F>(c: Constructor<F>) => Monad<F> =
 export function monadLawsOf<F>(instance: Monad<F>): MonadLaws<F> {
   return new (class extends MonadLaws<F> { public readonly F = instance })()
 }
+
+//---

--- a/test/core/try.test.ts
+++ b/test/core/try.test.ts
@@ -498,5 +498,5 @@ describe("Try.tailRecM", () => {
 
 describe("Try obeys type class laws", () => {
   laws.testEq(Try, inst.arbTry)
-  laws.testMonad(Try, jv.number, inst.arbTry, eqOf(Try))
+  laws.testMonadError(Try, jv.number, inst.arbTry, jv.string, eqOf(Try))
 })

--- a/test/effect/eval.test.ts
+++ b/test/effect/eval.test.ts
@@ -552,5 +552,5 @@ describe("Eval obeys type class laws", () => {
       }
     })()
 
-  laws.testMonad(Eval, jv.number, inst.arbEval, eq)
+  laws.testMonadError(Eval, jv.number, inst.arbEval, jv.string, eq)
 })

--- a/test/flow/applicativeError.test.js.flow
+++ b/test/flow/applicativeError.test.js.flow
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import type { EvalK, TypeClass } from "../../src/funfix"
+import {
+  Equiv,
+  ApplicativeError,
+  ApplicativeErrorLaws,
+  Applicative,
+  ApplicativeLaws,
+  Apply,
+  ApplyLaws,
+  Functor,
+  FunctorLaws,
+  applicativeErrorOf,
+  applicativeErrorLawsOf,
+  Eval,
+  Either,
+  applyMixins
+} from "../../src/funfix"
+
+const erasure: ApplicativeError<any, any> = ApplicativeError._funErasure
+const typeId: string = ApplicativeError._funTypeId
+const supertypes: string[] = ApplicativeError._funSupertypeIds
+const tc: TypeClass<ApplicativeError<any, any>> = ApplicativeError
+
+const F: ApplicativeError<Eval<any>, any> = applicativeErrorOf(Eval)
+const applicative: Applicative<Eval<any>> = F
+const apply: Apply<Eval<any>> = F
+const functor: Functor<Eval<any>> = F
+
+const laws1: ApplicativeErrorLaws<Eval<any>, any> = applicativeErrorLawsOf(F)
+const laws2: ApplicativeLaws<Eval<any>> = laws1
+const laws3: ApplyLaws<Eval<any>> = laws1
+const laws4: FunctorLaws<Eval<any>> = laws1
+
+// $ExpectError
+const err5: ApplicativeErrorLaws<string> = applicativeErrorLawsOf(F)
+
+class ApplicativeErrorLawsForEval implements ApplicativeErrorLaws<Eval<any>, any> {
+  +F: ApplicativeError<Eval<any>, any> = applicativeErrorOf(Eval);
+
+  // Mixed-in
+  covariantIdentity: <A>(fa: EvalK<A>) => Equiv<EvalK<A>>;
+  covariantComposition: <A, B, C>(fa: EvalK<A>, f: (a: A) => B, g: (b: B) => C) => Equiv<EvalK<C>>;
+  applyComposition: <A, B, C>(fa: EvalK<A>, fab: EvalK<(a: A) => B>, fbc: EvalK<(b: B) => C>) => Equiv<EvalK<C>>;
+  applyProductConsistency: <A, B>(fa: EvalK<A>, f: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  applyMap2Consistency: <A, B>(fa: EvalK<A>, f: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  applicativeIdentity: <A>(fa: EvalK<A>) => Equiv<EvalK<A>>;
+  applicativeHomomorphism: <A, B>(a: A, f: (a: A) => B) => Equiv<EvalK<B>>;
+  applicativeInterchange: <A, B>(a: A, ff: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  applicativeMap: <A, B>(fa: EvalK<A>, f: (a: A) => B) => Equiv<EvalK<B>>;
+  applicativeComposition: <A, B, C>(fa: EvalK<A>, fab: EvalK<(a: A) => B>, fbc: EvalK<(b: B) => C>) => Equiv<EvalK<C>>;
+  applicativeUnit: <A>(a: A) => Equiv<EvalK<A>>;
+
+  applicativeErrorRecoverWith: <A>(e: any, f: (e: any) => EvalK<A>) => Equiv<EvalK<A>>;
+  applicativeErrorRecover: <A>(e: any, f: (e: any) => A) => Equiv<EvalK<A>>;
+  recoverWithPure: <A>(a: A, f: (e: any) => EvalK<A>) => Equiv<EvalK<A>>;
+  recoverPure: <A>(a: A, f: (e: any) => A) => Equiv<EvalK<A>>;
+  raiseErrorAttempt: (e: any) => Equiv<EvalK<Either<any, void>>>;
+  pureAttempt: <A>(a: A) => Equiv<EvalK<Either<any, A>>>;
+}
+
+applyMixins(ApplicativeErrorLawsForEval, [ApplicativeErrorLaws])

--- a/test/flow/eval.test.js.flow
+++ b/test/flow/eval.test.js.flow
@@ -18,7 +18,7 @@
 /* @flow */
 
 import * as ff from "../../src/funfix"
-import { Try, Right } from "../../src/funfix"
+import { Try, Right, Either } from "../../src/funfix"
 import { Eval } from "../../src/effect"
 import {
   Functor,
@@ -86,6 +86,10 @@ const recover6: Eval<Object> = dogEval.recoverWith(_ => Eval.now(new Human()))
 const recoverE1: Eval<string> = dogEval.recoverWith(_ => Eval.now(new Human()))
 // $ExpectError
 const recoverE2: Eval<Dog> = dogEval.recover(_ => new Animal())
+
+const a1: Eval<Either<any, Dog>> = dogEval.attempt()
+// $ExpectError
+const a2: Eval<Either<any, Cat>> = dogEval.attempt()
 
 // Map and flatMap
 const r14: Eval<Cat> = dogEval.map(_ => new Cat())

--- a/test/flow/monadError.test.js.flow
+++ b/test/flow/monadError.test.js.flow
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import type { EvalK, TypeClass } from "../../src/funfix"
+import {
+  Equiv,
+  MonadError,
+  MonadErrorLaws,
+  ApplicativeError,
+  ApplicativeErrorLaws,
+  Applicative,
+  ApplicativeLaws,
+  Apply,
+  ApplyLaws,
+  Functor,
+  FunctorLaws,
+  monadErrorOf,
+  monadErrorLawsOf,
+  Eval,
+  Either,
+  applyMixins
+} from "../../src/funfix"
+
+const erasure: MonadError<any, any> = MonadError._funErasure
+const typeId: string = MonadError._funTypeId
+const supertypes: string[] = MonadError._funSupertypeIds
+const tc: TypeClass<MonadError<any, any>> = MonadError
+
+const F: MonadError<Eval<any>, any> = monadErrorOf(Eval)
+const apError: ApplicativeError<Eval<any>, any> = F
+const applicative: Applicative<Eval<any>> = F
+const apply: Apply<Eval<any>> = F
+const functor: Functor<Eval<any>> = F
+
+const laws1: MonadErrorLaws<Eval<any>, any> = monadErrorLawsOf(F)
+const laws2: ApplicativeErrorLaws<Eval<any>, any> = laws1
+const laws3: ApplicativeLaws<Eval<any>> = laws1
+const laws4: ApplyLaws<Eval<any>> = laws1
+const laws5: FunctorLaws<Eval<any>> = laws1
+
+// $ExpectError
+const err5: MonadErrorLaws<string> = monadErrorLawsOf(F)
+
+class MonadErrorLawsForEval implements MonadErrorLaws<Eval<any>, any> {
+  +F: MonadError<Eval<any>, any> = monadErrorOf(Eval);
+
+  // Functor
+  covariantIdentity: <A>(fa: EvalK<A>) => Equiv<EvalK<A>>;
+  covariantComposition: <A, B, C>(fa: EvalK<A>, f: (a: A) => B, g: (b: B) => C) => Equiv<EvalK<C>>;
+  // Apply
+  applyComposition: <A, B, C>(fa: EvalK<A>, fab: EvalK<(a: A) => B>, fbc: EvalK<(b: B) => C>) => Equiv<EvalK<C>>;
+  applyProductConsistency: <A, B>(fa: EvalK<A>, f: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  applyMap2Consistency: <A, B>(fa: EvalK<A>, f: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  // FlatMap
+  flatMapAssociativity: <A, B, C>(fa: EvalK<A>, f: (a: A) => EvalK<B>, g: (b: B) => EvalK<C>) => Equiv<EvalK<C>>;
+  flatMapConsistentApply: <A, B>(fa: EvalK<A>, fab: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  followedByConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<B>>;
+  followedByLConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<B>>;
+  forEffectConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<A>>;
+  forEffectLConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<A>>;
+  tailRecMConsistentFlatMap: <A>(a: A, f: (a: A) => EvalK<A>) => Equiv<EvalK<A>>;
+  // Applicative
+  applicativeIdentity: <A>(fa: EvalK<A>) => Equiv<EvalK<A>>;
+  applicativeHomomorphism: <A, B>(a: A, f: (a: A) => B) => Equiv<EvalK<B>>;
+  applicativeInterchange: <A, B>(a: A, ff: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  applicativeMap: <A, B>(fa: EvalK<A>, f: (a: A) => B) => Equiv<EvalK<B>>;
+  applicativeComposition: <A, B, C>(fa: EvalK<A>, fab: EvalK<(a: A) => B>, fbc: EvalK<(b: B) => C>) => Equiv<EvalK<C>>;
+  applicativeUnit: <A>(a: A) => Equiv<EvalK<A>>;
+  // Monad
+  monadLeftIdentity: <A, B>(a: A, f: (a: A) => EvalK<B>) => Equiv<EvalK<B>>;
+  monadRightIdentity: <A, B>(fa: EvalK<A>) => Equiv<EvalK<A>>;
+  mapFlatMapCoherence: <A, B>(fa: EvalK<A>, f: (a: A) => B) => Equiv<EvalK<B>>;
+  tailRecMStackSafety: () => Equiv<EvalK<number>>;
+  // ApplicativeError
+  monadErrorRecoverWith: <A>(e: any, f: (e: any) => EvalK<A>) => Equiv<EvalK<A>>;
+  monadErrorRecover: <A>(e: any, f: (e: any) => A) => Equiv<EvalK<A>>;
+  recoverWithPure: <A>(a: A, f: (e: any) => EvalK<A>) => Equiv<EvalK<A>>;
+  recoverPure: <A>(a: A, f: (e: any) => A) => Equiv<EvalK<A>>;
+  raiseErrorAttempt: (e: any) => Equiv<EvalK<Either<any, void>>>;
+  pureAttempt: <A>(a: A) => Equiv<EvalK<Either<any, A>>>;
+  // MonadError
+  monadErrorLeftZero: <A, B>(e: any, f: (a: A) => EvalK<B>) => Equiv<EvalK<B>>
+}
+
+applyMixins(MonadErrorLawsForEval, [MonadErrorLaws])

--- a/test/types/laws.test.ts
+++ b/test/types/laws.test.ts
@@ -18,13 +18,14 @@
 import * as jv from "jsverify"
 import * as laws from "../laws"
 import { Box, BoxApplicative } from "./box"
+import { Success } from "../../src/core"
 import {
   eqOf, Eq, Applicative, applicativeOf,
   getTypeClassInstance,
   registerTypeClassInstance
 } from "../../src/types"
 
-const arbBox = jv.number.smap(n => new Box(n), b => b.value)
+const arbBox = jv.number.smap(n => new Box(Success(n)), b => b.value.get())
 
 describe("Eq<Box> obeys laws", () => {
   laws.testEq(Box, arbBox)
@@ -35,19 +36,27 @@ describe("Functor<Box> obeys laws", () => {
 })
 
 describe("Apply<Box> obeys laws", () => {
-  laws.testApply(Box, arbBox, t => new Box(t), eqOf(Box))
+  laws.testApply(Box, arbBox, t => new Box(Success(t)), eqOf(Box))
 })
 
 describe("Applicative<Box> obeys laws", () => {
   laws.testApplicative(Box, arbBox, eqOf(Box))
 })
 
+describe("ApplicativeError<Box> obeys laws", () => {
+  laws.testApplicativeError(Box, jv.number, arbBox, jv.string, eqOf(Box))
+})
+
 describe("FlatMap<Box> obeys laws", () => {
-  laws.testFlatMap(Box, jv.number, arbBox, x => new Box(x), eqOf(Box))
+  laws.testFlatMap(Box, jv.number, arbBox, x => new Box(Success(x)), eqOf(Box))
 })
 
 describe("Monad<Box> obeys laws", () => {
   laws.testMonad(Box, jv.number, arbBox, eqOf(Box))
+})
+
+describe("MonadError<Box> obeys laws", () => {
+  laws.testMonadError(Box, jv.number, arbBox, jv.string, eqOf(Box))
 })
 
 describe("Type class registration", () => {


### PR DESCRIPTION
Adding these type classes:

- `ApplicativeError<F, E> extends Applicative<F>` 
- `MonadError<F, E> implements ApplicativeError<F, E>, Monad<F>`

Note that `ApplicativeError` is less useful, but still needed for data types such as [Validated](http://typelevel.org/cats/datatypes/validated.html).

Further implementation changes:

- `Eval<A>` now implements `MonadError<Eval, any>` (since `any` is the error type of `Eval`, would have been `Throwable` in Java)
- `Try<A>` now implements `MonadError<Try, any>` (since `any` is the error type of `Try`, would have been `Throwable` in Java)

Documentation links:

- [MonadError](https://funfix.org/api/classes/_types_monad_.monaderror.html)
- [ApplicativeError](https://funfix.org/api/classes/_types_applicative_.applicativeerror.html)