### PR TITLE
fix(future): improve transformWith to not leak memory due to cancelable

### DIFF
--- a/src/exec/cancelable.ts
+++ b/src/exec/cancelable.ts
@@ -545,6 +545,32 @@ export class MultiAssignCancelable implements IAssignCancelable {
   }
 
   /**
+   * In case the underlying reference is also a `MultiAssignCancelable`, then
+   * collapse its state into this one.
+   *
+   * ```typescript
+   * const c = Cancelable.of(() => console.info("Cancelled!"))
+   *
+   * const mc1 = new MultiAssignCancelable()
+   * mc1.update(c)
+   *
+   * const mc2 = new MultiAssignCancelable()
+   * mc2.update(mc1)
+   *
+   * // After this the underlying reference of `mc2` becomes `c`
+   * mc2.collapse()
+   * ```
+   */
+  public collapse(): this {
+    if (this._underlying && this._underlying instanceof MultiAssignCancelable) {
+      const ref = this._underlying
+      this._underlying = ref._underlying
+      this._canceled = ref._canceled
+    }
+    return this
+  }
+
+  /**
    * Returns a new [[MultiAssignCancelable]] that's empty.
    */
   public static empty(): MultiAssignCancelable {

--- a/test/exec/cancelable.test.ts
+++ b/test/exec/cancelable.test.ts
@@ -331,6 +331,26 @@ describe("MultiAssignmentCancelable", () => {
     expect(effect).toBe(0)
     ref.cancel() // no-op
   })
+
+  test("collapse on another MultiAssignCancelable", () => {
+    const mc1 = new MultiAssignCancelable()
+    const mc2 = new MultiAssignCancelable()
+
+    let effect = 0
+    const c1 = Cancelable.of(() => { effect += 1 })
+
+    mc1.update(c1).collapse()
+    mc2.update(mc1).collapse()
+    expect(effect).toBe(0)
+
+    mc2.cancel()
+    expect(mc2.isCanceled()).toBe(true)
+    expect(effect).toBe(1)
+    expect(mc1.isCanceled()).toBe(false)
+
+    mc1.update(mc2).collapse()
+    expect(mc1.isCanceled()).toBe(true)
+  })
 })
 
 describe("SerialAssignmentCancelable", () => {

--- a/test/exec/future.test.ts
+++ b/test/exec/future.test.ts
@@ -376,7 +376,10 @@ describe("FutureBuilder", () => {
       const never = Future.create(_ => c)
 
       let effect = 0
-      const f = Future.of(() => { effect += 1 }).flatMap(_ => never)
+      const f = Future.of(() => { effect += 1 })
+        .flatMap(_ => Future.pure(_))
+        .flatMap(_ => Future.pure(_))
+        .flatMap(_ => never)
 
       expect(effect).toBe(0); s.tick()
       expect(effect).toBe(1)


### PR DESCRIPTION
Long-running / infinite loops can leak memory:

```typescript
function longLoop(n: number): Future<number> {
  return Future.pure(n).flatMap(x => {
    if (x <= 0) return Future.pure(0)
    return longLoop(x - 1)
  })
}

const f = longLoop(10000)
```

By holding on to that `f` we are holding on to every cancelable reference created in every `flatMap` invocation, so in this example a chain of `10000` references.