### PR TITLE
feat: Add Future ops - sequence, firstCompletedOf, traverse, timeout 

### DIFF
--- a/src/core/disjunctions.ts
+++ b/src/core/disjunctions.ts
@@ -1521,8 +1521,9 @@ export class Try<A> implements std.IEquals<Try<A>> {
    *
    * This operation is the `Applicative.map2`.
    */
-  static map2<A1,A2,R>(fa1: Try<A1>, fa2: Try<A2>,
-                       f: (a1: A1, a2: A2) => R): Try<R> {
+  static map2<A1,A2,R>(
+    fa1: Try<A1>, fa2: Try<A2>,
+    f: (a1: A1, a2: A2) => R): Try<R> {
 
     if (fa1.isFailure()) return ((fa1 as any) as Try<R>)
     if (fa2.isFailure()) return ((fa2 as any) as Try<R>)

--- a/src/core/errors.js.flow
+++ b/src/core/errors.js.flow
@@ -41,3 +41,7 @@ declare export class IllegalStateError extends Error {
 declare export class IllegalArgumentError extends Error {
   constructor(message?: string): IllegalArgumentError;
 }
+
+declare export class TimeoutError extends Error {
+  constructor(message?: string): TimeoutError;
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -136,3 +136,13 @@ export class NotImplementedError extends Error {
     this.name = "NotImplementedError"
   }
 }
+
+/**
+ * Signals that completion of a procedure took longer than anticipated.
+ */
+export class TimeoutError extends Error {
+  constructor(message?: string) {
+    super(message)
+    this.name = "TimeoutError"
+  }
+}

--- a/src/exec/future.js.flow
+++ b/src/exec/future.js.flow
@@ -46,6 +46,8 @@ declare export class Future<+A> {
   toPromise(): Promise<A>;
 
   delayResult(delay: number | Duration): Future<A>;
+  timeoutTo<AA>(after: number | Duration, fallback: () => Future<AA>): Future<A | AA>;
+  timeout(after: number | Duration): Future<A>;
 
   // From IPromiseLike
   then(onFulfilled?: (value: A) => any, onRejected?: (error: any) => any): Future<any>;
@@ -65,7 +67,10 @@ declare export class Future<+A> {
   static tailRecM<A, B>(a: A, f: (a: A) => Future<Either<A, B>>): Future<B>;
   static fromPromise<A>(ref: IPromiseLike<A>, ec?: Scheduler): Future<A>;
 
-  static sequence<A>(values: Future<A>[] | Iterable<Future<A>>, ec?: Scheduler): Future<A[]>;
+  static firstCompletedOf<A>(list: Future<A>[] | Iterable<Future<A>>, ec?: Scheduler): Future<A>;
+  static sequence<A>(list: Future<A>[] | Iterable<Future<A>>, ec?: Scheduler): Future<A[]>;
+  static traverse<A>(list: A[] | Iterable<A>, parallelism?: number, ec?: Scheduler):
+    <B>(f: (a: A) => Future<B>) => Future<B[]>;
 
   static map2<A1, A2, R>(
     fa1: Future<A1>, fa2: Future<A2>, f: (a1: A1, a2: A2) => R,

--- a/src/exec/future.js.flow
+++ b/src/exec/future.js.flow
@@ -20,6 +20,7 @@
 import { Option, Try, Either } from "../core/disjunctions"
 import { Scheduler } from "./scheduler"
 import { ICancelable } from "./cancelable"
+import { Duration } from "./time"
 
 // Sorry for the `any` usage in this definition, however at the time of writing
 // Flow 0.53 does not support a type more specific than this. You can also blame
@@ -44,6 +45,8 @@ declare export class Future<+A> {
   recover<AA>(f: (e: any) => AA): Future<A | AA>;
   toPromise(): Promise<A>;
 
+  delayResult(delay: number | Duration): Future<A>;
+
   // From IPromiseLike
   then(onFulfilled?: (value: A) => any, onRejected?: (error: any) => any): Future<any>;
 
@@ -58,6 +61,29 @@ declare export class Future<+A> {
   static raise(e: any, ec?: Scheduler): Future<empty>;
   static create<A>(register: (cb: (a: Try<A>) => void) => (ICancelable | void), ec?: Scheduler): Future<A>;
   static unit(): Future<void>;
+  static delayedTick<A>(delay: number | Duration, ec?: Scheduler): Future<void>;
   static tailRecM<A, B>(a: A, f: (a: A) => Future<Either<A, B>>): Future<B>;
   static fromPromise<A>(ref: IPromiseLike<A>, ec?: Scheduler): Future<A>;
+
+  static sequence<A>(values: Future<A>[] | Iterable<Future<A>>, ec?: Scheduler): Future<A[]>;
+
+  static map2<A1, A2, R>(
+    fa1: Future<A1>, fa2: Future<A2>, f: (a1: A1, a2: A2) => R,
+    ec?: Scheduler): Future<R>;
+  static map3<A1, A2, A3, R>(
+    fa1: Future<A1>, fa2: Future<A2>, fa3: Future<A3>,
+    f: (a1: A1, a2: A2, a3: A3) => R,
+    ec?: Scheduler): Future<R>;
+  static map4<A1, A2, A3, A4, R>(
+    fa1: Future<A1>, fa2: Future<A2>, fa3: Future<A3>, fa4: Future<A4>,
+    f: (a1: A1, a2: A2, a3: A3, a4: A4) => R,
+    ec?: Scheduler): Future<R>;
+  static map5<A1, A2, A3, A4, A5, R>(
+    fa1: Future<A1>, fa2: Future<A2>, fa3: Future<A3>, fa4: Future<A4>, fa5: Future<A5>,
+    f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R,
+    ec?: Scheduler): Future<R>;
+  static map6<A1, A2, A3, A4, A5, A6, R>(
+    fa1: Future<A1>, fa2: Future<A2>, fa3: Future<A3>, fa4: Future<A4>, fa5: Future<A5>, fa6: Future<A6>,
+    f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => R,
+    ec?: Scheduler): Future<R>;
 }

--- a/src/exec/internals.ts
+++ b/src/exec/internals.ts
@@ -53,3 +53,21 @@ export function arrayBSearchInsertPos<A>(array: Array<A>, f: (a: A) => number):
     return 0
   }
 }
+
+/**
+ * Internal utility that builds an iterator out of an `Iterable` or an `Array`.
+ */
+export function iterableToArray<A>(values: Iterable<A>): A[] {
+  if (!values) return []
+  if (Object.prototype.toString.call(values) === "[object Array]")
+    return values as A[]
+
+  const cursor = values[Symbol.iterator]()
+  const arr: A[] = []
+
+  while (true) {
+    const item = cursor.next()
+    if (item.value) arr.push(item.value)
+    if (item.done) return arr
+  }
+}

--- a/src/exec/time.js.flow
+++ b/src/exec/time.js.flow
@@ -19,6 +19,7 @@
 
 declare export class TimeUnit {
   ord: number;
+  label: string;
   convert(duration: number, unit: TimeUnit): number;
   toNanos(d: number): number;
   toMicros(d: number): number;
@@ -59,6 +60,7 @@ declare export class Duration {
 
   equals(other: Duration): boolean;
   hashCode(): number;
+  toString(): string;
 
   static of(value: number | Duration): Duration;
   static zero(): Duration;

--- a/src/exec/time.ts
+++ b/src/exec/time.ts
@@ -198,6 +198,16 @@ export abstract class TimeUnit {
    * ```
    */
   abstract ord: number
+
+  /**
+   * A human readable label for this unit.
+   */
+  abstract label: string
+
+  /** Override for `Object.toString`. */
+  toString(): string {
+    return this.label.toUpperCase()
+  }
 }
 
 /** @hidden */ const C0 = 1
@@ -230,6 +240,7 @@ function x(d: number, m: number, over: number): number {
 /** @hidden */
 class Nanoseconds extends TimeUnit {
   ord: number = 0
+  label = "nanoseconds"
   convert(duration: number, unit: TimeUnit): number { return unit.toNanos(duration) }
   toNanos(d: number): number { return d }
   toMicros(d: number): number { return trunc(d / (C1 / C0)) }
@@ -250,6 +261,7 @@ export const NANOSECONDS: TimeUnit =
 /** @hidden */
 class Microseconds extends TimeUnit {
   ord: number = 1
+  label = "microseconds"
   convert(duration: number, unit: TimeUnit): number { return unit.toMicros(duration) }
   toNanos(d: number): number { return x(d, C1 / C0, trunc(MAX / (C1 / C0))) }
   toMicros(d: number): number { return d }
@@ -270,6 +282,7 @@ export const MICROSECONDS: TimeUnit =
 /** @hidden */
 class Milliseconds extends TimeUnit {
   ord: number = 2
+  label = "milliseconds"
   convert(duration: number, unit: TimeUnit): number { return unit.toMillis(duration) }
   toNanos(d: number): number { return x(d, C2 / C0, trunc(MAX / (C2 / C0))) }
   toMicros(d: number): number { return x(d, C2 / C1, trunc(MAX / (C2 / C1))) }
@@ -290,6 +303,7 @@ export const MILLISECONDS: TimeUnit =
 /** @hidden */
 class Seconds extends TimeUnit {
   ord: number = 3
+  label = "seconds"
   convert(duration: number, unit: TimeUnit): number { return unit.toSeconds(duration) }
   toNanos(d: number): number { return x(d, C3 / C0, trunc(MAX / (C3 / C0))) }
   toMicros(d: number): number { return x(d, C3 / C1, trunc(MAX / (C3 / C1))) }
@@ -309,6 +323,7 @@ export const SECONDS: TimeUnit =
 /** @hidden */
 class Minutes extends TimeUnit {
   ord: number = 4
+  label = "minutes"
   convert(duration: number, unit: TimeUnit): number { return unit.toMinutes(duration) }
   toNanos(d: number): number { return x(d, C4 / C0, trunc(MAX / (C4 / C0))) }
   toMicros(d: number): number { return x(d, C4 / C1, trunc(MAX / (C4 / C1))) }
@@ -328,6 +343,7 @@ export const MINUTES: TimeUnit =
 /** @hidden */
 class Hours extends TimeUnit {
   ord: number = 5
+  label = "hours"
   convert(duration: number, unit: TimeUnit): number { return unit.toHours(duration) }
   toNanos(d: number): number { return x(d, C5 / C0, trunc(MAX / (C5 / C0))) }
   toMicros(d: number): number { return x(d, C5 / C1, trunc(MAX / (C5 / C1))) }
@@ -347,6 +363,7 @@ export const HOURS: TimeUnit =
 /** @hidden */
 class Days extends TimeUnit {
   ord: number = 6
+  label = "days"
   convert(duration: number, unit: TimeUnit): number { return unit.toDays(duration) }
   toNanos(d: number): number { return x(d, C6 / C0, trunc(MAX / (C6 / C0))) }
   toMicros(d: number): number { return x(d, C6 / C1, trunc(MAX / (C6 / C1))) }
@@ -531,6 +548,15 @@ export class Duration implements IEquals<Duration> {
     } else {
       return 422082410550358
     }
+  }
+
+  toString(): string {
+    if (this.isFinite())
+      return `${this.duration} ${this.unit.label}`
+    else if (this.duration >= 0)
+      return "[end of time]"
+    else
+      return "[beginning of time]"
   }
 
   /**

--- a/src/types/instances.ts
+++ b/src/types/instances.ts
@@ -385,8 +385,11 @@ export class FutureInstances implements MonadError<Future<any>, any> {
     return (fa as Future<A>).recover(f as ((e: any) => A))
   }
 
+  map2<A, B, Z>(fa: FutureK<A>, fb: FutureK<B>, f: (a: A, b: B) => Z): Future<Z> {
+    return Future.map2(fa as any, fb as any, f as any)
+  }
+
   // Mixed-in
-  map2: <A, B, Z>(fa: FutureK<A>, fb: FutureK<B>, f: (a: A, b: B) => Z) => Future<Z>
   product: <A, B>(fa: FutureK<A>, fb: FutureK<B>) => FutureK<[A, B]>
   followedBy: <A, B>(fa: FutureK<A>, fb: FutureK<B>) => Future<B>
   followedByL: <A, B>(fa: FutureK<A>, fb: () => FutureK<B>) => Future<B>

--- a/test/flow/core/errors.test.js.flow
+++ b/test/flow/core/errors.test.js.flow
@@ -27,7 +27,8 @@ import {
   NoSuchElementError,
   IllegalInheritanceError,
   IllegalStateError,
-  IllegalArgumentError
+  IllegalArgumentError,
+  TimeoutError
 } from "../../../src/core"
 
 new ff.CompositeError([])
@@ -99,3 +100,15 @@ new IllegalArgumentError()
 new IllegalArgumentError("message")
 // $ExpectError
 new IllegalArgumentError(1)
+
+// ---
+
+new ff.TimeoutError()
+new ff.TimeoutError("message")
+// $ExpectError
+new ff.TimeoutError(1)
+
+new TimeoutError()
+new TimeoutError("message")
+// $ExpectError
+new TimeoutError(1)

--- a/test/flow/exec/future.test.js.flow
+++ b/test/flow/exec/future.test.js.flow
@@ -143,6 +143,19 @@ const me6: Future<number> = Future.map6(
   (a, b, c, d, e, f) => a + b + c + d + e + f,
   Scheduler.global.get())
 
+const ft1: Future<number> = Future.pure(1).timeout(1000)
+const ft2: Future<number> = Future.pure(1).timeout(Duration.of(1000))
+const ft3: Future<number | string> = Future.pure.timeoutTo(1000, () => Future.pure("Hello!"))
+const ft4: Future<number | string> = Future.pure.timeoutTo(Duration.of(1000), () => Future.pure("Hello!"))
+const ft5: Future<number> = Future.firstCompletedOf(arr)
+const ft6: Future<number> = Future.firstCompletedOf(arr, Scheduler.global.get())
+
+const arr2 = [1, 2, 3]
+const tAll1: Future<number[]> = Future.traverse(arr2)(Future.pure)
+const tAll2: Future<number[]> = Future.traverse(arr2, 2)(Future.pure)
+const tAll3: Future<number[]> = Future.traverse(arr2, 2, Scheduler.global.get())(Future.pure)
+const tAll4: Future<string[]> = Future.traverse(arr2)(x => Future.pure(x.toString()))
+
 // Type classes
 // Option.__types
 

--- a/test/flow/exec/future.test.js.flow
+++ b/test/flow/exec/future.test.js.flow
@@ -37,7 +37,8 @@ import {
   Monad,
   monadOf,
   MonadError,
-  monadErrorOf
+  monadErrorOf,
+  Duration
 } from "../../../src/"
 
 const fa1: Future<number> = Future.pure(1)
@@ -93,8 +94,56 @@ const cve3: Future<Dog> = Future.pure(new Dog).recover(_ => new Cat)
 // $ExpectError
 const cve4: Future<Dog> = Future.pure(new Dog).recoverWith(_ => Future.pure(new Cat))
 
-// Type classes
+const tick1: Future<void> = Future.delayedTick(1000)
+const tick2: Future<void> = Future.delayedTick(1000, Scheduler.global.get())
+const tick3: Future<void> = Future.delayedTick(Duration.of(1000))
+const tick4: Future<void> = Future.delayedTick(Duration.of(1000), Scheduler.global.get())
 
+const delay1: Future<number> = Future.pure(1).delayResult(1000)
+const delay2: Future<number> = Future.pure(1).delayResult(Duration.of(1000))
+
+const arr: Future<number>[] = [delay1, delay2]
+const all1: Future<number[]> = Future.sequence(arr)
+const all2: Future<number[]> = Future.sequence(arr, Scheduler.global.get())
+
+const m2: Future<number> = Future.map2(
+  Future.pure(1), Future.pure(2),
+  (a, b) => a + b)
+const m3: Future<number> = Future.map3(
+  Future.pure(1), Future.pure(2), Future.pure(3),
+  (a, b, c) => a + b + c)
+const m4: Future<number> = Future.map4(
+  Future.pure(1), Future.pure(2), Future.pure(3), Future.pure(4),
+  (a, b, c, d) => a + b + c + d)
+const m5: Future<number> = Future.map5(
+  Future.pure(1), Future.pure(2), Future.pure(3), Future.pure(4), Future.pure(5),
+  (a, b, c, d, e) => a + b + c + d + e)
+const m6: Future<number> = Future.map6(
+  Future.pure(1), Future.pure(2), Future.pure(3), Future.pure(4), Future.pure(5), Future.pure(6),
+  (a, b, c, d, e, f) => a + b + c + d + e + f)
+
+const me2: Future<number> = Future.map2(
+  Future.pure(1), Future.pure(2),
+  (a, b) => a + b,
+  Scheduler.global.get())
+const me3: Future<number> = Future.map3(
+  Future.pure(1), Future.pure(2), Future.pure(3),
+  (a, b, c) => a + b + c,
+  Scheduler.global.get())
+const me4: Future<number> = Future.map4(
+  Future.pure(1), Future.pure(2), Future.pure(3), Future.pure(4),
+  (a, b, c, d) => a + b + c + d,
+  Scheduler.global.get())
+const me5: Future<number> = Future.map5(
+  Future.pure(1), Future.pure(2), Future.pure(3), Future.pure(4), Future.pure(5),
+  (a, b, c, d, e) => a + b + c + d + e,
+  Scheduler.global.get())
+const me6: Future<number> = Future.map6(
+  Future.pure(1), Future.pure(2), Future.pure(3), Future.pure(4), Future.pure(5), Future.pure(6),
+  (a, b, c, d, e, f) => a + b + c + d + e + f,
+  Scheduler.global.get())
+
+// Type classes
 // Option.__types
 
 const functor1: Functor<Future<any>> = functorOf(Future)

--- a/test/ts/core/errors.test.ts
+++ b/test/ts/core/errors.test.ts
@@ -22,7 +22,8 @@ import {
   IllegalStateError,
   NoSuchElementError,
   IllegalArgumentError,
-  NotImplementedError
+  NotImplementedError,
+  TimeoutError
 } from "../../../src/"
 
 describe("DummyError", () => {
@@ -112,6 +113,15 @@ describe("NotImplementedError", () => {
     const ex = new NotImplementedError("dummy")
 
     expect(ex.name).toBe("NotImplementedError")
+    expect(ex.message).toBe("dummy")
+  })
+})
+
+describe("TimeoutError", () => {
+  it("has custom message", () => {
+    const ex = new TimeoutError("dummy")
+
+    expect(ex.name).toBe("TimeoutError")
     expect(ex.message).toBe("dummy")
   })
 })

--- a/test/ts/exec/future.test.ts
+++ b/test/ts/exec/future.test.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { is, Try, Success, Failure, Some, None, DummyError, Left, Right, IllegalStateError } from "../../../src/core"
-import { Future, IPromiseLike, TestScheduler, Scheduler, BoolCancelable, Cancelable } from "../../../src/exec"
+import { is, Try, Success, Failure, Some, None, DummyError, Left, Right, IllegalStateError, TimeoutError, IllegalArgumentError } from "../../../src/core"
+import { Future, IPromiseLike, TestScheduler, Scheduler, BoolCancelable, Cancelable, Duration } from "../../../src/exec"
 import { Eq } from "../../../src/types"
 
 import * as jv from "jsverify"
@@ -673,7 +673,7 @@ describe("Future.sequence", () => {
       return sum
     })
 
-    expect(is(f.value(), Some(Success(6))))
+    expect(is(f.value(), Some(Success(6)))).toBe(true)
   })
 
   test("protects against broken Iterable", () => {
@@ -777,6 +777,305 @@ describe("Future.sequence", () => {
     ec.tick()
     expect(is(all.value(), Some(Failure(dummy1))))
     expect(ec.triggeredFailures().length).toBe(1)
+  })
+})
+
+describe("Future.firstCompletedOf", () => {
+  test("happy path", () => {
+    const f = Future.firstCompletedOf([Future.pure(1), Future.pure(2)])
+    expect(is(f.value(), Some(Success(1)))).toBe(true)
+  })
+
+  test("timeout", () => {
+    const ec = new TestScheduler()
+    let effect = 0
+    const never = Future.create(_ => Cancelable.of(() => { effect += 1 }), ec)
+
+    const fa = never.timeout(Duration.of(1000))
+    ec.tick()
+    expect(fa.value()).toBe(None)
+
+    ec.tick(1000)
+    const v = fa.value()
+
+    expect(!v.isEmpty()).toBeTruthy()
+    expect(v.get().isFailure()).toBeTruthy()
+    expect(v.get().failed().get() instanceof TimeoutError).toBeTruthy()
+    expect((v.get().failed().get() as TimeoutError).message).toBe("1000 milliseconds")
+    expect(effect).toBe(1)
+  })
+
+  test("timeoutTo", () => {
+    const ec = new TestScheduler()
+    let effect = 0
+    const never = Future.create(_ => Cancelable.of(() => { effect += 1 }), ec)
+
+    const fa = never.timeoutTo(1000, () => Future.pure(1000))
+    ec.tick()
+    expect(fa.value()).toBe(None)
+
+    ec.tick(1000)
+    const v = fa.value()
+
+    expect(is(fa.value(), Some(Success(1000))))
+    expect(effect).toBe(1)
+  })
+
+  test("report success, cancel the losers", () => {
+    const ec = new TestScheduler()
+    let effect = 0
+
+    const create = (delay: number, inc: number) => Future.create(
+      cb => {
+        const t = ec.scheduleOnce(delay, () => cb(Success(inc)))
+        return Cancelable.of(() => { effect += inc; t.cancel() })
+      }, ec)
+
+    const first = Future.firstCompletedOf(
+      [create(3000, 1), create(2000, 2), create(3000, 3)],
+      ec)
+
+    ec.tick(2000)
+    expect(is(first.value(), Some(Success(2)))).toBe(true)
+    expect(effect).toBe(1 + 3)
+  })
+
+  test("report failure, cancel the losers", () => {
+    const ec = new TestScheduler()
+    const dummy = new DummyError("dummy")
+    let effect = 0
+
+    const create = (delay: number, inc: number, fail: boolean) => Future.create(
+      cb => {
+        const t = ec.scheduleOnce(delay, () => {
+          if (!fail) cb(Success(inc))
+          else cb(Failure(dummy))
+        })
+
+        return Cancelable.of(() => { effect += inc; t.cancel() })
+      }, ec)
+
+    const first = Future.firstCompletedOf(
+      [create(3000, 1, false), create(2000, 2, true), create(3000, 3, false)],
+      ec)
+
+    ec.tick(2000)
+    expect(is(first.value(), Some(Failure(dummy)))).toBe(true)
+    expect(effect).toBe(1 + 3)
+  })
+
+  test("works with actual Iterable", () => {
+    const ec = new TestScheduler()
+    let effect = 0
+
+    const iter = {
+      [Symbol.iterator]: () => {
+        let index = 0
+        return {
+          next: () => {
+            if (index++ < 3)
+              return { value: Future.pure(index, ec).delayResult(4000 - index * 1000), done: false }
+            else
+              return { done: true }
+          }
+        }
+      }
+    }
+
+    const f = Future.firstCompletedOf(iter as Iterable<Future<number>>, ec)
+    expect(f.value()).toBe(None)
+
+    ec.tick(1000)
+    expect(is(f.value(), Some(Success(1))))
+  })
+
+  test("protects against broken Iterable", () => {
+    const ec = new TestScheduler()
+    const dummy = new DummyError("dummy")
+    let effect = 0
+
+    const never = () => Future.create(_ => Cancelable.of(() => { effect += 1 }), ec)
+
+    const iter = {
+      [Symbol.iterator]: () => {
+        let index = 0
+        return {
+          next: () => {
+            if (index++ < 3) return { value: never(), done: false }
+            else throw dummy
+          }
+        }
+      }
+    }
+
+    const all = Future.firstCompletedOf(iter as any, ec)
+    ec.tick()
+    expect(is(all.value(), Some(Failure(dummy)))).toBe(true)
+    expect(effect).toBe(3)
+  })
+
+  test("signaling result is blocked after first", () => {
+    const ec = new TestScheduler()
+    const dummy1 = new DummyError("dummy1")
+    const dummy2 = new DummyError("dummy1")
+
+    const all = Future.firstCompletedOf([
+      Future.raise(dummy1, ec),
+      Future.of(() => 1, ec),
+      Future.of(() => null, ec).flatMap(_ => Future.raise(dummy2, ec))
+    ], ec)
+
+    ec.tick()
+    expect(is(all.value(), Some(Failure(dummy1))))
+    expect(ec.triggeredFailures().length).toBe(1)
+  })
+
+  test("protect against broken cancelable", () => {
+    const ec = new TestScheduler()
+    let effect = 0
+    const never = () => Future.create(_ => Cancelable.of(() => { effect += 1 }), ec)
+
+    const dummy = new DummyError("dummy")
+    const fail = Future.create(_ => Cancelable.of(() => { throw dummy }), ec)
+
+    const all = Future.firstCompletedOf([never(), never(), fail, never(), never()], ec)
+    all.cancel()
+
+    expect(effect).toBe(4)
+    const errs = ec.triggeredFailures()
+    expect(errs.length).toBe(1)
+    expect(errs[0]).toBe(dummy)
+  })
+
+  test("empty list is illegal", () => {
+    const f = Future.firstCompletedOf([])
+    expect(!f.value().isEmpty()).toBeTruthy()
+    expect(f.value().get().isFailure()).toBeTruthy()
+    expect(f.value().get().failed().get() instanceof IllegalArgumentError).toBeTruthy()
+  })
+})
+
+describe("Future.traverse", () => {
+  test("happy path for parallelism = 1, 2, 4, Infinity", () => {
+    const ec = new TestScheduler()
+    const list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const parallelism = [1, 2, 4, Infinity]
+    const f = (n: number) => Future.pure(n * 2, ec)
+
+    for (const p of parallelism) {
+      const all = Future.traverse(list, p, ec)(f).map(x => {
+        let sum = 0
+        for (let i = 0; i < x.length; i++) sum += x[i]
+        return sum
+      })
+
+      ec.tick()
+      expect(all.value().isEmpty()).toBeFalsy()
+      expect(all.value().get().get()).toBe(110)
+    }
+  })
+
+  test("parallelism <= 0 throws", () => {
+    expect(() => Future.traverse([], -1)(Future.pure)).toThrow()
+  })
+
+  test("empty list is empty", () => {
+    const ec = new TestScheduler()
+    const f = Future.traverse([], Infinity, ec)(Future.pure).map(_ => _.toString())
+
+    ec.tick()
+    expect(is(f.value(), Some(Success("")))).toBeTruthy()
+  })
+
+  test("protect against user errors in generator", () => {
+    const ec = new TestScheduler()
+    const list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const dummy = new DummyError("dummy")
+
+    let effect = 0
+    const never = (n: number) => Future.create(_ => Cancelable.of(() => { effect += n }), ec)
+
+    const f = Future.traverse(list, Infinity, ec)(a => {
+      if (a === 6) throw dummy
+      return never(a)
+    })
+
+    ec.tick()
+    expect(is(f.value(), Some(Failure(dummy)))).toBeTruthy()
+    expect(effect).toBe(1 + 2 + 3 + 4 + 5)
+  })
+
+  test("handles null list", () => {
+    const ec = new TestScheduler()
+    const f = Future.traverse(null as any, Infinity, ec)(Future.pure).map(_ => _.toString())
+
+    ec.tick()
+    expect(is(f.value(), Some(Success("")))).toBeTruthy()
+  })
+
+  test("works with actual Iterable", () => {
+    const ec = new TestScheduler()
+    let effect = 0
+
+    const iter = {
+      [Symbol.iterator]: () => {
+        let index = 0
+        return {
+          next: () => {
+            index += 1
+            if (index === 1) return { value: null, done: false }
+            else if (index <= 4) return { value: index - 1, done: false }
+            else return { done: true }
+          }
+        }
+      }
+    }
+
+    const f = Future.traverse(iter as Iterable<number>, Infinity, ec)(Future.pure)
+      .map(arr => {
+        let sum = 0
+        for (const e of arr) sum += e
+        return sum
+      })
+
+    ec.tick()
+    expect(is(f.value(), Some(Success(6)))).toBe(true)
+  })
+
+  test("protects against broken Iterable", () => {
+    const ec = new TestScheduler()
+    const dummy = new DummyError("dummy")
+    let effect = 0
+
+    const iter = {
+      [Symbol.iterator]: () => {
+        let index = 0
+        return {
+          next: () => {
+            if (index++ < 3) return { value: index, done: false }
+            else throw dummy
+          }
+        }
+      }
+    }
+
+    const all = Future.traverse(iter as any, Infinity, ec)(Future.pure)
+    ec.tick()
+    expect(is(all.value(), Some(Failure(dummy)))).toBe(true)
+  })
+
+  test("actual execution", () => {
+    const list = [1, 2, 3]
+    const fa = Future.traverse(list)(Future.pure)
+      .map(arr => {
+        let sum = 0
+        for (const e of arr) sum += e
+        return sum
+      })
+
+    return fa.toPromise().then(x => {
+      expect(x).toBe(6)
+    })
   })
 })
 

--- a/test/ts/exec/time.test.ts
+++ b/test/ts/exec/time.test.ts
@@ -99,6 +99,10 @@ describe("NANOSECONDS", () => {
     jv.integer,
     d => NANOSECONDS.convert(d, MICROSECONDS) === MICROSECONDS.toNanos(d)
   )
+
+  test("toString", () => {
+    expect(NANOSECONDS.toString().toLowerCase()).toBe("nanoseconds")
+  })
 })
 
 describe("MICROSECONDS", () => {
@@ -181,6 +185,10 @@ describe("MICROSECONDS", () => {
     jv.integer,
     d => MICROSECONDS.convert(d, NANOSECONDS) === NANOSECONDS.toMicros(d)
   )
+
+  test("toString", () => {
+    expect(MICROSECONDS.toString().toLowerCase()).toBe("microseconds")
+  })
 })
 
 describe("MILLISECONDS", () => {
@@ -268,6 +276,10 @@ describe("MILLISECONDS", () => {
     jv.integer,
     d => MILLISECONDS.convert(d, MICROSECONDS) === MICROSECONDS.toMillis(d)
   )
+
+  test("toString", () => {
+    expect(MILLISECONDS.toString().toLowerCase()).toBe("milliseconds")
+  })
 })
 
 describe("SECONDS", () => {
@@ -360,6 +372,10 @@ describe("SECONDS", () => {
     jv.integer,
     d => SECONDS.convert(d, MILLISECONDS) === MILLISECONDS.toSeconds(d)
   )
+
+  test("toString", () => {
+    expect(SECONDS.toString().toLowerCase()).toBe("seconds")
+  })
 })
 
 describe("MINUTES", () => {
@@ -457,6 +473,10 @@ describe("MINUTES", () => {
     jv.integer,
     d => MINUTES.convert(d, SECONDS) === SECONDS.toMinutes(d)
   )
+
+  test("toString", () => {
+    expect(MINUTES.toString().toLowerCase()).toBe("minutes")
+  })
 })
 
 describe("HOURS", () => {
@@ -554,6 +574,10 @@ describe("HOURS", () => {
     jv.integer,
     d => HOURS.convert(d, SECONDS) === SECONDS.toHours(d)
   )
+
+  test("toString", () => {
+    expect(HOURS.toString().toLowerCase()).toBe("hours")
+  })
 })
 
 describe("DAYS", () => {
@@ -661,9 +685,18 @@ describe("DAYS", () => {
     jv.integer,
     d => DAYS.convert(d, HOURS) === HOURS.toDays(d)
   )
+
+  test("toString", () => {
+    expect(DAYS.toString().toLowerCase()).toBe("days")
+  })
 })
 
 describe("Duration (finite)", () => {
+  test("toString", () => {
+    expect(Duration.days(2).toString()).toBe("2 days")
+    expect(Duration.minutes(3).toString()).toBe("3 minutes")
+  })
+
   test("it can convert from nanos()", () => {
     const ref = Duration.nanos(86400000000000)
     expect(ref.isFinite()).toBe(true)
@@ -731,6 +764,11 @@ describe("Duration (finite)", () => {
 })
 
 describe("Duration (infinite)", () => {
+  test("toString", () => {
+    expect(Duration.inf().toString()).toBe("[end of time]")
+    expect(Duration.negInf().toString()).toBe("[beginning of time]")
+  })
+
   test("#equals", () => {
     expect(is(Duration.inf(), Duration.inf())).toBe(true)
     expect(is(Duration.negInf(), Duration.negInf())).toBe(true)


### PR DESCRIPTION
Released in version `4.5.0`, can be seen in **[JSDoc documentation](https://funfix.org/archive/v4.5.0/classes/_exec_future_.future.html)**.

## Future.sequence

`Future.sequence` is the equivalent of `Promise.all`, expect that:

1. it's cancellable, cancelling everything if cancellation is triggered
2. on failure of either of the futures, all the rest get cancelled
3. on failure the result is signaled immediately, without waiting for any other future to complete

Signature:
```typescript
abstract class Future<A> {
  // ...
  static sequence<A>(list: Future<A>[] | Iterable<Future<A>>, 
    ec: Scheduler = Scheduler.global.get()): Future<A[]>
  // ...
}
```

Sample:
```typescript
const f1 = Future.of(() => 1)
const f2 = Future.of(() => 2)
const f3 = Future.of(() => 3)

// Yields [1, 2, 3]
const all: Future<number[]> = Future.sequence([f1, f2, f3]) 
```

Similarly `Future` now has `map2`, `map3`, `map4`, `map5` and `map6`, built on top of `Future.sequence`, to use in cases where the types are heterogeneous:

```typescript
const fEmployee: Future<Employee> = fetchEmployee(id)
const fHistory: Future<History> = fetchHistoryFor(id)

Future.map2(fEmployee, fHistory, (employee, history) => {
  triggerReport(employee, history)
})
```

## Future.traverse

The definition is a little more complicated, this one being curried for good reasons:

```typescript
abstract class Future<A> {
  // ...
  static traverse<A>(list: A[] | Iterable<A>, parallelism: number = Infinity, ec: Scheduler = Scheduler.global.get()):
    <B>(f: (a: A) => Future<B>) => Future<B[]>
  //...
}
```

The more generic version of `Future.sequence`, also having the ability to do batched processing.

```typescript
const list = [1, 2, 3, 4]

// Yields [2, 4, 6, 8]
Future.traverse(list)(a => Future.pure(a * 2))

// ... is equivalent to:
Future.sequence(list.map(_ => _ * 2))
```

By default all futures get processed in parallel, but we can specify a parallelism factor to limit the parallelism:

```typescript
const userIDs = [1, 2, 3, 4]

// Make at most 2 requests in parallel:
Future.traverse(userIDs, 2)(fetchUserDetails)
```

## Future.firstCompletedOf

The equivalent of `Promise.race`, except that when one of the futures "wins the race", all others get cancelled:

```typescript
abstract class Future<A> {
  // ...
  static firstCompletedOf<A>(list: Future<A>[] | Iterable<Future<A>>, 
    ec: Scheduler = Scheduler.global.get()): Future<A>
  // ...
}
```

Based on this we can now specify `timeout` and `timeoutTo` operations that triggers an error or does a fallback in case a future does not complete in a timely manner:

```typescript
abstract class Future<A> {
  // ...
  timeout(after: number | Duration): Future<A>
  // ...
  timeoutTo<AA>(after: number | Duration, fallback: () => Future<AA>): Future<A | AA>
}
```

These are built on top of `Future.firstCompletedOf` and in case the source times-out, it gets cancelled.

```typescript
const fa = Future.of(() => 1).delayResult(10000)

fa.timeout(1000)

// ... being equivalent to ...
fa.timeoutTo(1000, () => Future.raise(new TimeoutError()))

// ... being equivalent to ...
const err = Future.raise(new TimeoutError()).delayResult(1000)
Future.firstCompletedOf([fa, err])
```

## Future.delayResult

In support for the above, a `delayResult` method has been added, with a supporting static function called `delayedTick`:

```typescript
abstract class Future<A> {
  // ...
  delayResult(delay: number | Duration): Future<A>

  // ...
  static delayedTick<A>(delay: number | Duration, ec: Scheduler = Scheduler.global.get()): Future<void>
}
```

These can be used to delay the results of future references, or to delay the execution of asynchronous processes in general, example:

```typescript
// Future is already processed, but delay signalling its result by 1 second:
const f = Future.pure(1).delayResult(1000)

// Delay the execution of the given function by 1 second:
Future.delayedTick(1000).map(_ => console.log("Hello!"))
```