### PR TITLE
IO, the monadic data type for controlling side effects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ notifications:
 node_js:
   - '7.10'
 before_script:
-  - npm install -g yarn
-  - yarn cache clean
-  - yarn install
+  - npm prune && npm cache clean
+  - npm install
 script:
-  - yarn build && yarn test:prod
+  - npm run build && npm run test:prod
 after_success:
   - ./scripts/upload-coverage.sh
   - ./scripts/gh-pages-publish.js

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,5 @@
     "packages/*"
   ],
   "version": "5.0.1",
-  "npmClient": "yarn",
   "hoist": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.0.1",
+  "version": "0.0.0-development",
   "hoist": true
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tslint-config-standard": "^6.0.1",
     "tslint-eslint-rules": "^4.1.1",
     "typedoc": "^0.8.0",
-    "typescript": "~2.5.1",
+    "typescript": "rc",
     "validate-commit-msg": "^2.14.0"
   },
   "config": {

--- a/packages/funfix-effect/package.json
+++ b/packages/funfix-effect/package.json
@@ -18,7 +18,8 @@
     "copy-flow": "../../scripts/copy-flow.js ."
   },
   "dependencies": {
-    "funfix-core": "0.0.0-development"
+    "funfix-core": "0.0.0-development",
+    "funfix-exec": "0.0.0-development"
   },
   "files": [
     "dist",

--- a/packages/funfix-effect/rootdoc.md
+++ b/packages/funfix-effect/rootdoc.md
@@ -11,9 +11,8 @@ types for dealing with laziness and side effects.
 
 |              |                                                                                        |
 |--------------|--------------------------------------------------------------------------------------- |
-| {@link Eval} | a lawful, lazy, monadic data type, that can control evaluation, inspired by the `Eval` type in [Typelevel Cats](http://typelevel.org/cats/) and by the `Coeval` type in [Monix](https://monix.io), the equivalent of Haskell's `IO`, but that can only handle immediate execution and not async boundaries. |
-
-N.B. an equivalent `Task` / `IO` type is coming 😉
+| [Eval]{@link Eval} | lawful, lazy, monadic data type, that can control evaluation, inspired by the `Eval` type in [Typelevel Cats](http://typelevel.org/cats/) and by the `Coeval` type in [Monix](https://monix.io), a more simple `IO`-like type that can only handle immediate execution, no async boundaries, no error handling, not being meant for suspending side effects. |
+| [IO]{@link IO}   | lawful, lazy, monadic data type, capable of expressing and composing side effectful actions, including asynchronous, being the most potent and capable alternative to JavaScript's `Promise`, inspired by Haskell's `IO` and by the [Monix Task](https://monix.io/docs/2x/eval/task.html) |
 
 ## Usage
 

--- a/packages/funfix-effect/src/eval.js.flow
+++ b/packages/funfix-effect/src/eval.js.flow
@@ -53,7 +53,7 @@ declare export class Eval<+A> {
   static pure<A>(value: A): Eval<A>;
   static now<A>(value: A): Eval<A>;
   static unit(): Eval<void>;
-  static raise<A>(e: Throwable): Eval<A>;
+  static raise(e: Throwable): Eval<empty>;
   static always<A>(thunk: () => A): Eval<A>;
   static once<A>(thunk: () => A): Eval<A>;
   static suspend<A>(thunk: () => Eval<A>): Eval<A>;

--- a/packages/funfix-effect/src/eval.ts
+++ b/packages/funfix-effect/src/eval.ts
@@ -362,7 +362,7 @@ export class Eval<A> {
    * Returns an `Eval` that on execution is always finishing in error
    * emitting the specified exception.
    */
-  static raise(e: Throwable): Eval<never> { return new Raise(e) }
+  static raise<A = never>(e: Throwable): Eval<A> { return new Raise(e) }
 
   /**
    * Promote a `thunk` function to an `Eval`, catching exceptions in
@@ -443,7 +443,7 @@ class Now<A> extends Eval<A> {
    * @param value is the value that's going to be returned
    * when `get()` is called.
    */
-  constructor(public value: A) { super() }
+  constructor(public readonly value: A) { super() }
 
   get(): A { return this.value }
   run(): Try<A> { return Try.success(this.value) }
@@ -468,7 +468,7 @@ class Raise extends Eval<never> {
    * @param error is the error value that's going to be
    * throw when `get()` is called.
    */
-  constructor(public error: Throwable) { super() }
+  constructor(public readonly error: Throwable) { super() }
 
   get(): never { throw this.error }
   run(): Try<never> { return Try.failure<never>(this.error) }
@@ -519,7 +519,7 @@ class Once<A> extends Eval<A> {
  * @private
  */
 class Always<A> extends Eval<A> {
-  constructor(public thunk: () => A) { super() }
+  constructor(public readonly thunk: () => A) { super() }
   run(): Try<A> { return Try.of(this.thunk) }
 
   toString(): string { return `Eval.always([thunk])` }
@@ -532,7 +532,7 @@ class Always<A> extends Eval<A> {
  * @private
  */
 class Suspend<A> extends Eval<A> {
-  constructor(public thunk: () => Eval<A>) { super() }
+  constructor(public readonly thunk: () => Eval<A>) { super() }
   toString(): string { return `Eval.suspend([thunk])` }
 }
 
@@ -546,8 +546,8 @@ class Suspend<A> extends Eval<A> {
  */
 class FlatMap<A, B> extends Eval<B> {
   constructor(
-    public source: Eval<A>,
-    public f: (a: A) => Eval<B>) { super() }
+    public readonly source: Eval<A>,
+    public readonly f: (a: A) => Eval<B>) { super() }
 
   toString(): string {
     return `Eval#FlatMap(${String(this.source)}, [function])`

--- a/packages/funfix-effect/src/index.js.flow
+++ b/packages/funfix-effect/src/index.js.flow
@@ -18,3 +18,4 @@
 /* @flow */
 
 declare export * from "./eval";
+declare export * from "./io";

--- a/packages/funfix-effect/src/index.ts
+++ b/packages/funfix-effect/src/index.ts
@@ -16,3 +16,4 @@
  */
 
 export * from "./eval"
+export * from "./io"

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import type { Throwable } from "funfix-core"
+import { Either, Try } from "funfix-core";
+import { ICancelable, StackedCancelable, Scheduler, Future } from "funfix-exec";
+
+declare export class IO<+A> {
+  run<A>(ec?: Scheduler): Future<A>;
+  runOnComplete<A>(cb: (result: Try<A>) => void, ec?: Scheduler): ICancelable;
+
+  map<B>(f: (a: A) => B): IO<B>;
+  flatMap<B>(f: (a: A) => IO<B>): IO<B>;
+  chain<B>(f: (a: A) => IO<B>): IO<B>;
+  transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R>;
+  transformWith<R>(failure: (e: Throwable) => IO<R>, success: (a: A) => IO<R>): IO<R>;
+  recover<AA>(f: (e: Throwable) => AA): IO<A | AA>;
+  recoverWith<AA>(f: (e: Throwable) => IO<AA>): IO<A | AA>;
+  attempt(): IO<Either<Throwable, A>>;
+  forEachL(cb: (a: A) => void): IO<void>;
+
+  +_funKindF: IO<any>;
+  +_funKindA: A;
+  static +_funErasure: IO<any>;
+
+  static of<A>(thunk: () => A): IO<A>;
+  static pure<A>(value: A): IO<A>;
+  static now<A>(value: A): IO<A>;
+  static unit(): IO<void>;
+  static raise(e: Throwable): IO<empty>;
+  static fromTry<A>(a: Try<A>): IO<A>;
+  static always<A>(thunk: () => A): IO<A>;
+  static once<A>(thunk: () => A): IO<A>;
+  static suspend<A>(thunk: () => IO<A>): IO<A>;
+  static defer<A>(thunk: () => IO<A>): IO<A>;
+  static async<A>(register: (ec: Scheduler, cb: (a: Try<A>) => void) => ICancelable | void): IO<A>;
+  static asyncUnsafe<A>(register: IORegister<A>): IO<A>;
+  static tailRecM<A, B>(a: A, f: (a: A) => IO<Either<A, B>>): IO<B>;
+}
+
+export type IORegister<A> =
+  (context: IOContext, callback: (result: Try<A>) => void) => void;
+
+declare export class IOContext {
+  +scheduler: Scheduler;
+  +connection: StackedCancelable;
+  +options: IOOptions;
+  constructor(scheduler: Scheduler, connection?: StackedCancelable, options?: IOOptions): IOContext;
+
+  markAsyncBoundary(): void;
+  shouldCancel(): boolean;
+}
+
+export type IOOptions = {
+  autoCancelableRunLoops: boolean;
+};

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -33,7 +33,9 @@ declare export class IO<+A> {
   doOnFinish(f: (e: Option<Throwable>) => IO<void>): IO<A>;
   doOnCancel(callback: IO<void>): IO<A>;
   flatMap<B>(f: (a: A) => IO<B>): IO<B>;
+  followedBy<B>(fb: IO<B>): IO<B>;
   forEach(cb: (a: A) => void): IO<void>;
+  forEffect<B>(fb: IO<B>): IO<A>;
   executeForked(ec?: Scheduler): IO<A>;
   executeWithModel(em: ExecutionModel): IO<A>;
   executeWithOptions(set: IOOptions): IO<A>;

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -18,7 +18,7 @@
 /* @flow */
 
 import type { Throwable } from "funfix-core"
-import { Either, Try } from "funfix-core";
+import { Either, Try, Option } from "funfix-core";
 import { ICancelable, StackedCancelable, Scheduler, Future, ExecutionModel, Duration } from "funfix-exec";
 
 declare export class IO<+A> {
@@ -30,6 +30,8 @@ declare export class IO<+A> {
   chain<B>(f: (a: A) => IO<B>): IO<B>;
   delayExecution(delay: number | Duration): IO<A>;
   delayResult(delay: number | Duration): IO<A>;
+  doOnFinish(f: (e: Option<Throwable>) => IO<void>): IO<A>;
+  doOnCancel(callback: IO<void>): IO<A>;
   flatMap<B>(f: (a: A) => IO<B>): IO<B>;
   forEach(cb: (a: A) => void): IO<void>;
   executeForked(ec?: Scheduler): IO<A>;
@@ -40,6 +42,8 @@ declare export class IO<+A> {
   memoizeOnSuccess(): IO<A>;
   recover<AA>(f: (e: Throwable) => AA): IO<A | AA>;
   recoverWith<AA>(f: (e: Throwable) => IO<AA>): IO<A | AA>;
+  timeout(after: number | Duration): IO<A>;
+  timeoutTo<AA>(after: number | Duration, fallback: IO<AA>): IO<A | AA>;
   transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R>;
   transformWith<R>(failure: (e: Throwable) => IO<R>, success: (a: A) => IO<R>): IO<R>;
 
@@ -56,6 +60,7 @@ declare export class IO<+A> {
   static deferFuture<A>(thunk: () => Future<A>): IO<A>;
   static deferFutureAction<A>(f: (ec: Scheduler) => Future<A>): IO<A>;
   static delayedTick<A>(delay: number | Duration): IO<void>;
+  static firstCompletedOf<A>(list: Iterable<IO<A>>): IO<A>;
   static fromFuture<A>(fa: Future<A>): IO<A>;
   static fromTry<A>(a: Try<A>): IO<A>;
   static fork<A>(fa: IO<A>, ec?: Scheduler): IO<A>;
@@ -74,8 +79,8 @@ declare export class IO<+A> {
   static parMap6<A1, A2, A3, A4, A5, A6, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, fa5: IO<A5>, fa6: IO<A6>, f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => R): IO<R>;
   static pure<A>(value: A): IO<A>;
   static raise(e: Throwable): IO<empty>;
-  static sequence<A>(list: IO<A>[] | Iterable<IO<A>>): IO<A[]>;
-  static gather<A>(list: IO<A>[] | Iterable<IO<A>>): IO<A[]>;
+  static sequence<A>(list: Iterable<IO<A>>): IO<A[]>;
+  static gather<A>(list: Iterable<IO<A>>): IO<A[]>;
   static shift(ec?: Scheduler): IO<void>;
   static suspend<A>(thunk: () => IO<A>): IO<A>;
   static tailRecM<A, B>(a: A, f: (a: A) => IO<Either<A, B>>): IO<B>;

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -25,33 +25,35 @@ declare export class IO<+A> {
   run<A>(ec?: Scheduler): Future<A>;
   runOnComplete<A>(cb: (result: Try<A>) => void, ec?: Scheduler): ICancelable;
 
-  map<B>(f: (a: A) => B): IO<B>;
-  flatMap<B>(f: (a: A) => IO<B>): IO<B>;
+  attempt(): IO<Either<Throwable, A>>;
   chain<B>(f: (a: A) => IO<B>): IO<B>;
-  transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R>;
-  transformWith<R>(failure: (e: Throwable) => IO<R>, success: (a: A) => IO<R>): IO<R>;
+  flatMap<B>(f: (a: A) => IO<B>): IO<B>;
+  forEachL(cb: (a: A) => void): IO<void>;
+  executeWithOptions(set: IOOptions): IO<A>;
+  map<B>(f: (a: A) => B): IO<B>;
   recover<AA>(f: (e: Throwable) => AA): IO<A | AA>;
   recoverWith<AA>(f: (e: Throwable) => IO<AA>): IO<A | AA>;
-  attempt(): IO<Either<Throwable, A>>;
-  forEachL(cb: (a: A) => void): IO<void>;
+  transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R>;
+  transformWith<R>(failure: (e: Throwable) => IO<R>, success: (a: A) => IO<R>): IO<R>;
 
   +_funKindF: IO<any>;
   +_funKindA: A;
   static +_funErasure: IO<any>;
 
-  static of<A>(thunk: () => A): IO<A>;
-  static pure<A>(value: A): IO<A>;
-  static now<A>(value: A): IO<A>;
-  static unit(): IO<void>;
-  static raise(e: Throwable): IO<empty>;
-  static fromTry<A>(a: Try<A>): IO<A>;
   static always<A>(thunk: () => A): IO<A>;
-  static once<A>(thunk: () => A): IO<A>;
-  static suspend<A>(thunk: () => IO<A>): IO<A>;
-  static defer<A>(thunk: () => IO<A>): IO<A>;
   static async<A>(register: (ec: Scheduler, cb: (a: Try<A>) => void) => ICancelable | void): IO<A>;
   static asyncUnsafe<A>(register: IORegister<A>): IO<A>;
+  static defer<A>(thunk: () => IO<A>): IO<A>;
+  static fromTry<A>(a: Try<A>): IO<A>;
+  static now<A>(value: A): IO<A>;
+  static of<A>(thunk: () => A): IO<A>;
+  static once<A>(thunk: () => A): IO<A>;
+  static pure<A>(value: A): IO<A>;
+  static raise(e: Throwable): IO<empty>;
+  static suspend<A>(thunk: () => IO<A>): IO<A>;
   static tailRecM<A, B>(a: A, f: (a: A) => IO<Either<A, B>>): IO<B>;
+  static unit(): IO<void>;
+  static unsafeStart<A>(source: IO<A>, context: IOContext, cb: (r: Try<A>) => void): void | ICancelable;
 }
 
 export type IORegister<A> =

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -19,16 +19,19 @@
 
 import type { Throwable } from "funfix-core"
 import { Either, Try } from "funfix-core";
-import { ICancelable, StackedCancelable, Scheduler, Future } from "funfix-exec";
+import { ICancelable, StackedCancelable, Scheduler, Future, ExecutionModel } from "funfix-exec";
 
 declare export class IO<+A> {
   run<A>(ec?: Scheduler): Future<A>;
   runOnComplete<A>(cb: (result: Try<A>) => void, ec?: Scheduler): ICancelable;
 
   attempt(): IO<Either<Throwable, A>>;
+  asyncBoundary(ec?: Scheduler): IO<A>;
   chain<B>(f: (a: A) => IO<B>): IO<B>;
   flatMap<B>(f: (a: A) => IO<B>): IO<B>;
   forEachL(cb: (a: A) => void): IO<void>;
+  executeForked(ec?: Scheduler): IO<A>;
+  executeWithModel(em: ExecutionModel): IO<A>;
   executeWithOptions(set: IOOptions): IO<A>;
   map<B>(f: (a: A) => B): IO<B>;
   memoize(): IO<A>;
@@ -51,11 +54,13 @@ declare export class IO<+A> {
   static deferFutureAction<A>(f: (ec: Scheduler) => Future<A>): IO<A>;
   static fromFuture<A>(fa: Future<A>): IO<A>;
   static fromTry<A>(a: Try<A>): IO<A>;
+  static fork<A>(fa: IO<A>, ec?: Scheduler): IO<A>;
   static now<A>(value: A): IO<A>;
   static of<A>(thunk: () => A): IO<A>;
   static once<A>(thunk: () => A): IO<A>;
   static pure<A>(value: A): IO<A>;
   static raise(e: Throwable): IO<empty>;
+  static shift(ec?: Scheduler): IO<void>;
   static suspend<A>(thunk: () => IO<A>): IO<A>;
   static tailRecM<A, B>(a: A, f: (a: A) => IO<Either<A, B>>): IO<B>;
   static unit(): IO<void>;

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -31,6 +31,8 @@ declare export class IO<+A> {
   forEachL(cb: (a: A) => void): IO<void>;
   executeWithOptions(set: IOOptions): IO<A>;
   map<B>(f: (a: A) => B): IO<B>;
+  memoize(): IO<A>;
+  memoizeOnSuccess(): IO<A>;
   recover<AA>(f: (e: Throwable) => AA): IO<A | AA>;
   recoverWith<AA>(f: (e: Throwable) => IO<AA>): IO<A | AA>;
   transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R>;
@@ -44,6 +46,10 @@ declare export class IO<+A> {
   static async<A>(register: (ec: Scheduler, cb: (a: Try<A>) => void) => ICancelable | void): IO<A>;
   static asyncUnsafe<A>(register: IORegister<A>): IO<A>;
   static defer<A>(thunk: () => IO<A>): IO<A>;
+  static deferAction<A>(f: (ec: Scheduler) => IO<A>): IO<A>;
+  static deferFuture<A>(thunk: () => Future<A>): IO<A>;
+  static deferFutureAction<A>(f: (ec: Scheduler) => Future<A>): IO<A>;
+  static fromFuture<A>(fa: Future<A>): IO<A>;
   static fromTry<A>(a: Try<A>): IO<A>;
   static now<A>(value: A): IO<A>;
   static of<A>(thunk: () => A): IO<A>;

--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -19,7 +19,7 @@
 
 import type { Throwable } from "funfix-core"
 import { Either, Try } from "funfix-core";
-import { ICancelable, StackedCancelable, Scheduler, Future, ExecutionModel } from "funfix-exec";
+import { ICancelable, StackedCancelable, Scheduler, Future, ExecutionModel, Duration } from "funfix-exec";
 
 declare export class IO<+A> {
   run<A>(ec?: Scheduler): Future<A>;
@@ -28,8 +28,10 @@ declare export class IO<+A> {
   attempt(): IO<Either<Throwable, A>>;
   asyncBoundary(ec?: Scheduler): IO<A>;
   chain<B>(f: (a: A) => IO<B>): IO<B>;
+  delayExecution(delay: number | Duration): IO<A>;
+  delayResult(delay: number | Duration): IO<A>;
   flatMap<B>(f: (a: A) => IO<B>): IO<B>;
-  forEachL(cb: (a: A) => void): IO<void>;
+  forEach(cb: (a: A) => void): IO<void>;
   executeForked(ec?: Scheduler): IO<A>;
   executeWithModel(em: ExecutionModel): IO<A>;
   executeWithOptions(set: IOOptions): IO<A>;
@@ -41,6 +43,7 @@ declare export class IO<+A> {
   transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R>;
   transformWith<R>(failure: (e: Throwable) => IO<R>, success: (a: A) => IO<R>): IO<R>;
 
+  +_funADType: "pure" | "always" | "once" | "flatMap" | "async" | "memoize";
   +_funKindF: IO<any>;
   +_funKindA: A;
   static +_funErasure: IO<any>;
@@ -52,14 +55,27 @@ declare export class IO<+A> {
   static deferAction<A>(f: (ec: Scheduler) => IO<A>): IO<A>;
   static deferFuture<A>(thunk: () => Future<A>): IO<A>;
   static deferFutureAction<A>(f: (ec: Scheduler) => Future<A>): IO<A>;
+  static delayedTick<A>(delay: number | Duration): IO<void>;
   static fromFuture<A>(fa: Future<A>): IO<A>;
   static fromTry<A>(a: Try<A>): IO<A>;
   static fork<A>(fa: IO<A>, ec?: Scheduler): IO<A>;
+  static map2<A1, A2, R>(fa1: IO<A1>, fa2: IO<A2>, f: (a1: A1, a2: A2) => R): IO<R>;
+  static map3<A1, A2, A3, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, f: (a1: A1, a2: A2, a3: A3) => R): IO<R>;
+  static map4<A1, A2, A3, A4, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, f: (a1: A1, a2: A2, a3: A3, a4: A4) => R): IO<R>;
+  static map5<A1, A2, A3, A4, A5, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, fa5: IO<A5>, f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R): IO<R>;
+  static map6<A1, A2, A3, A4, A5, A6, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, fa5: IO<A5>, fa6: IO<A6>, f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => R): IO<R>;
   static now<A>(value: A): IO<A>;
   static of<A>(thunk: () => A): IO<A>;
   static once<A>(thunk: () => A): IO<A>;
+  static parMap2<A1, A2, R>(fa1: IO<A1>, fa2: IO<A2>, f: (a1: A1, a2: A2) => R): IO<R>;
+  static parMap3<A1, A2, A3, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, f: (a1: A1, a2: A2, a3: A3) => R): IO<R>;
+  static parMap4<A1, A2, A3, A4, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, f: (a1: A1, a2: A2, a3: A3, a4: A4) => R): IO<R>;
+  static parMap5<A1, A2, A3, A4, A5, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, fa5: IO<A5>, f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) => R): IO<R>;
+  static parMap6<A1, A2, A3, A4, A5, A6, R>(fa1: IO<A1>, fa2: IO<A2>, fa3: IO<A3>, fa4: IO<A4>, fa5: IO<A5>, fa6: IO<A6>, f: (a1: A1, a2: A2, a3: A3, a4: A4, a5: A5, a6: A6) => R): IO<R>;
   static pure<A>(value: A): IO<A>;
   static raise(e: Throwable): IO<empty>;
+  static sequence<A>(list: IO<A>[] | Iterable<IO<A>>): IO<A[]>;
+  static gather<A>(list: IO<A>[] | Iterable<IO<A>>): IO<A[]>;
   static shift(ec?: Scheduler): IO<void>;
   static suspend<A>(thunk: () => IO<A>): IO<A>;
   static tailRecM<A, B>(a: A, f: (a: A) => IO<Either<A, B>>): IO<B>;

--- a/packages/funfix-effect/src/io.ts
+++ b/packages/funfix-effect/src/io.ts
@@ -342,7 +342,8 @@ export class IO<A> {
     )
   }
 
-  /** Returns a new `IO` in which `f` is scheduled to be run on
+  /**
+   * Returns a new `IO` in which `f` is scheduled to be run on
    * completion. This would typically be used to release any
    * resources acquired by this `IO`.
    *
@@ -2082,7 +2083,10 @@ function ioStartMemoize<A>(
   ioGenericRunLoop(io, ec, context, cb, null, bFirstInit, bRestInit)
 }
 
-/** Implementation for `IO.sequence`. */
+/**
+ * Implementation for `IO.sequence`.
+ * @hidden
+ */
 function ioSequence<A>(list: IO<A>[] | Iterable<IO<A>>): IO<A[]> {
   return IO.of(() => iteratorOf(list))
     .flatMap(cursor => ioSequenceLoop([], cursor))

--- a/packages/funfix-effect/src/io.ts
+++ b/packages/funfix-effect/src/io.ts
@@ -1,0 +1,940 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Either,
+  Try,
+  Success,
+  Failure,
+  Throwable
+} from "funfix-core"
+
+import {
+  ICancelable,
+  Cancelable,
+  StackedCancelable,
+  Scheduler,
+  Future
+} from "funfix-exec"
+
+/**
+ * `IO` represents a specification for a possibly lazy or
+ * asynchronous computation, which when executed will produce an `A`
+ * as a result, along with possible side-effects.
+ *
+ * Compared with Funfix's `Future` (see `funfix-exec`) or
+ * JavaScript's `Promise`, `IO` does not represent a running
+ * computation or a value detached from time, as `IO` does not execute
+ * anything when working with its builders or operators and it does
+ * not submit any work into the `Scheduler` or any run-loop for
+ * execution, the execution eventually taking place only after
+ * {@link IO.run} is called and not before that.
+ *
+ * ## Note on the ExecutionModel
+ *
+ * `IO` is conservative in how it introduces async boundaries.
+ * Transformations like `map` and `flatMap` for example will default
+ * to being executed on the current call stack on which the
+ * asynchronous computation was started. But one shouldn't make
+ * assumptions about how things will end up executed, as ultimately
+ * it is the implementation's job to decide on the best execution
+ * model. All you are guaranteed is asynchronous execution after
+ * executing `runAsync`.
+ *
+ * Currently the default `ExecutionModel` specifies batched execution
+ * by default and `IO` in its evaluation respects the injected
+ * `ExecutionModel`. If you want a different behavior, you need to
+ * execute the `IO` reference with a different scheduler.
+ *
+ * @final
+ */
+export class IO<A> {
+  /**
+   * Triggers the asynchronous execution.
+   *
+   * Without invoking `run` on a `IO`, nothing gets evaluated, as an
+   * `IO` has lazy behavior.
+   *
+   * Also see {@link IO.runOnComplete} for a version that takes a
+   * callback as parameter.
+   *
+   * @return a `Future` that will eventually complete with the
+   *         result produced by this `IO` on evaluation
+   */
+  run<A>(ec: Scheduler = Scheduler.global.get()): Future<A> {
+    return taskToFutureRunLoop(this, ec)
+  }
+
+  /**
+   * Triggers the asynchronous execution.
+   *
+   * Without invoking `run` on a `IO`, nothing gets evaluated, as an
+   * `IO` has lazy behavior.
+   *
+   * Also see {@link IO.run} for a version that returns a `Future`,
+   * which might be easier to work with, especially since a `Future`
+   * is `Promise`-like.
+   *
+   * @param cb is the callback that will be eventually called with
+   *        the final result, or error, when the evaluation completes
+   *
+   * @param ec is the scheduler that controls the triggering of
+   *        asynchronous boundaries (e.g. `setTimeout`)
+   *
+   * @return a cancelable action that can be triggered to cancel
+   *         the running computation, assuming that the implementation
+   *         of the source `IO` can be cancelled
+   */
+  runOnComplete<A>(
+    cb: (result: Try<A>) => void,
+    ec: Scheduler = Scheduler.global.get()): ICancelable {
+
+    const ref = ioGenericRunLoop(this, ec, null, cb, null, null, null)
+    return ref || Cancelable.empty()
+  }
+
+  /**
+   * Returns a new `IO` that applies the mapping function to the
+   * successful result emitted by the source.
+   *
+   * ```typescript
+   * IO.now(111).map(_ => _ * 2).get() // 222
+   * ```
+   */
+  map<B>(f: (a: A) => B): IO<B> {
+    return new IOFlatMap(this, (a: A) => IO.now(f(a)))
+  }
+
+  /**
+   * Creates a new `IO` by applying a function to the successful
+   * result of the source, and returns a new instance equivalent to
+   * the result of the function.
+   *
+   * ```typescript
+   * const rndInt = IO.of(() => {
+   *   const nr = Math.random() * 1000000
+   *   return nr & nr
+   * })
+   *
+   * const evenInt = () =>
+   *   rndInt.flatMap(int => {
+   *     if (i % 2 == 0)
+   *       return IO.now(i)
+   *     else // Retry until we have an even number!
+   *       return evenInt()
+   *   })
+   * ```
+   */
+  flatMap<B>(f: (a: A) => IO<B>): IO<B> {
+    return new IOFlatMap(this, f)
+  }
+
+  /**
+   * Alias for {@link IO.flatMap .flatMap}.
+   */
+  chain<B>(f: (a: A) => IO<B>): IO<B> {
+    return this.flatMap(f)
+  }
+
+  /**
+   * Creates a new `IO` by applying the 'success' function to the
+   * successful result of the source, or the 'error' function to the
+   * potential errors that might happen.
+   *
+   * This function is similar with {@link IO.map .map}, except that
+   * it can also transform errors and not just successful results.
+   *
+   * @param success is a function for transforming a successful result
+   * @param failure is function for transforming failures
+   */
+  transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): IO<R> {
+    return this.transformWith(
+      e => IO.now(failure(e)),
+      a => IO.now(success(a))
+    )
+  }
+
+  /**
+   * Creates a new `IO` by applying the 'success' function to the
+   * successful result of the source, or the 'error' function to the
+   * potential errors that might happen.
+   *
+   * This function is similar with {@link IO.flatMap .flatMap},
+   * except that it can also transform errors and not just successful
+   * results.
+   *
+   * @param success is a function for transforming a successful result
+   * @param failure is function for transforming failures
+   */
+  transformWith<R>(failure: (e: Throwable) => IO<R>, success: (a: A) => IO<R>): IO<R> {
+    return new IOFlatMap(this, success, failure)
+  }
+
+  /**
+   * Creates a new `IO` that will mirror the source on success,
+   * but on failure it will try to recover and yield a successful
+   * result by applying the given function `f` to the thrown error.
+   *
+   * This function is the equivalent of a `try/catch` statement,
+   * or the equivalent of {@link IO.map .map} for errors.
+   */
+  recover<AA>(f: (e: Throwable) => AA): IO<A | AA> {
+    return this.recoverWith(a => IO.now(f(a)))
+  }
+
+  /**
+   * Creates a new `IO` that will mirror the source on success,
+   * but on failure it will try to recover and yield a successful
+   * result by applying the given function `f` to the thrown error.
+   *
+   * This function is the equivalent of a `try/catch` statement,
+   * or the equivalent of {@link IO.flatMap .flatMap} for errors.
+   */
+  recoverWith<AA>(f: (e: Throwable) => IO<AA>): IO<A | AA> {
+    return this.transformWith(f, IO.now as any)
+  }
+
+  /**
+   * Handle errors by turning them into `Either` values.
+   *
+   * If there is no error, then a `Right` value will be returned instead.
+   * Errors can be handled by this method.
+   */
+  attempt(): IO<Either<Throwable, A>> {
+    return this.transform(
+      _ => Either.left<Throwable, A>(_),
+      Either.right)
+  }
+
+  /**
+   * Returns a new `IO` that upon evaluation will execute the given
+   * function for the generated element, transforming the source into
+   * an `IO<void>`.
+   */
+  forEachL(cb: (a: A) => void): IO<void> {
+    return this.map(cb)
+  }
+
+  /**
+   * Identifies the `IO` reference type, useful for debugging and
+   * for pattern matching in the implementation.
+   */
+  readonly _funADType: "pure" | "always" | "once" | "flatMap" | "async"
+
+  // Implements HK<F, A>
+  readonly _funKindF: IO<any>
+  readonly _funKindA: A
+
+  // Implements Constructor<T>
+  static readonly _funErasure: IO<any>
+
+  /**
+   * Alias for {@link IO.always}.
+   */
+  static of<A>(thunk: () => A): IO<A> {
+    return IO.always(thunk)
+  }
+
+  /**
+   * Lifts a value into the `IO` context.
+   *
+   * Alias for {@link IO.now}.
+   */
+  static pure<A>(value: A): IO<A> { return IO.now(value) }
+
+  /**
+   * Returns an `IO` that on execution is always successful,
+   * emitting the given strict value.
+   */
+  static now<A>(value: A): IO<A> { return new IOPure(Success(value)) }
+
+  /**
+   * Shorthand for `now(undefined as void)`, always returning
+   * the same reference as optimization.
+   */
+  static unit(): IO<void> {
+    return ioUnitRef
+  }
+
+  /**
+   * Returns an `IO` that on execution is always finishing in error
+   * emitting the specified exception.
+   */
+  static raise<A = never>(e: Throwable): IO<A> { return new IOPure(Failure(e)) }
+
+  /**
+   * Returns a `IO` reference that will signal the result of the
+   * given `Try<A>` reference upon evaluation.
+   */
+  static fromTry<A>(a: Try<A>): IO<A> { return new IOPure(a) }
+
+  /**
+   * Promote a `thunk` function to an `IO`, catching exceptions in
+   * the process.
+   *
+   * Note that since `IO` is not memoized by global, this will
+   * recompute the value each time the `IO` is executed.
+   */
+  static always<A>(thunk: () => A): IO<A> {
+    return new IOAlways(thunk)
+  }
+
+  /**
+   * Promote a `thunk` function to a `Coeval` that is memoized on the
+   * first evaluation, the result being then available on subsequent
+   * evaluations.
+   *
+   * Note this is equivalent with:
+   *
+   * ```typescript
+   * IO.always(thunk).memoize()
+   * ```
+   */
+  static once<A>(thunk: () => A): IO<A> {
+    return new IOOnce(thunk, false)
+  }
+
+  /**
+   * Promote a `thunk` function generating `IO` results to an `IO`
+   * of the same type.
+   */
+  static suspend<A>(thunk: () => IO<A>): IO<A> {
+    return IO.unit().flatMap(_ => thunk())
+  }
+
+  /**
+   * Promote a `thunk` function generating `IO` results to an `IO`
+   * of the same type.
+   *
+   * Alias for {@link IO.suspend}.
+   */
+  static defer<A>(thunk: () => IO<A>): IO<A> {
+    return IO.unit().flatMap(_ => thunk())
+  }
+
+  /**
+   * Create a `IO` from an asynchronous computation, which takes
+   * the form of a function with which we can register a callback.
+   *
+   * This can be used to translate from a callback-based API to a
+   * straightforward monadic version.
+   */
+  static async<A>(register: (ec: Scheduler, cb: (a: Try<A>) => void) => ICancelable | void): IO<A> {
+    return IO.asyncUnsafe<A>((ctx, cb) => {
+      const ec = ctx.scheduler
+      const conn = ctx.connection
+
+      // Forcing a light asynchronous boundary, otherwise
+      // stack overflows are possible
+      ec.trampoline(() => {
+        // Wrapping the callback in a safe implementation that
+        // provides idempotency guarantees and that pops from
+        // the given `StackedCancelable` at the right time
+        const safe = ioSafeCallback(ec, conn, cb)
+        try {
+          const ref = register(ec, safe)
+          // This `push` can be executed after `register`, even the
+          // `safe` callback gets executed immediately, because of
+          // the light async boundary in `ioSafeCallback`
+          conn.push(ref || Cancelable.empty())
+        } catch (e) {
+          safe(Failure(e))
+        }
+      })
+    })
+  }
+
+  /**
+   * Constructs a lazy [[IO]] instance whose result
+   * will be computed asynchronously.
+   *
+   * **WARNING:** Unsafe to use directly, only use if you know
+   * what you're doing. For building `IO` instances safely
+   * see {@link IO.async}.
+   *
+   * Rules of usage:
+   *
+   *  - the received `StackedCancelable` can be used to store
+   *    cancelable references that will be executed upon cancel;
+   *    every `push` must happen at the beginning, before any
+   *    execution happens and `pop` must happen afterwards
+   *    when the processing is finished, before signaling the
+   *    result
+   *  - before execution, an asynchronous boundary is recommended,
+   *    to avoid stack overflow errors, but can happen using the
+   *    scheduler's facilities for trampolined execution
+   *  - on signaling the result (`Success` or `Failure`),
+   *    another async boundary is necessary, but can also
+   *    happen with the scheduler's facilities for trampolined
+   *    execution (e.g. {@link Scheduler.trampoline})
+   *
+   * **WARNING:** note that not only is this builder unsafe, but also
+   * unstable, as the {@link IORegister} callback type is exposing
+   * volatile internal implementation details. This builder is meant
+   * to create optimized asynchronous tasks, but for normal usage
+   * prefer {@link IO.async}.
+   */
+  static asyncUnsafe<A>(register: IORegister<A>): IO<A> {
+    return new IOAsync(register)
+  }
+
+  /**
+   * Keeps calling `f` until a `Right(b)` is returned.
+   *
+   * Based on Phil Freeman's
+   * [Stack Safety for Free]{@link http://functorial.com/stack-safety-for-free/index.pdf}.
+   *
+   * Described in `FlatMap.tailRecM`.
+   */
+  static tailRecM<A, B>(a: A, f: (a: A) => IO<Either<A, B>>): IO<B> {
+    try {
+      return f(a).flatMap(either => {
+        if (either.isRight()) {
+          return IO.now(either.get())
+        } else {
+          // Recursive call
+          return IO.tailRecM(either.swap().get(), f)
+        }
+      })
+    } catch (e) {
+      return IO.raise(e)
+    }
+  }
+}
+
+/**
+ * `Pure` is an internal `IO` state that wraps any strict
+ * value in an `IO` reference. Returned by {@link IO.now}
+ * and {@link IO.raise}.
+ *
+ * @private
+ */
+class IOPure<A> extends IO<A> {
+  readonly _funADType: "pure" = "pure"
+
+  /**
+   * @param value is the value that's going to be returned
+   * when `get()` is called.
+   */
+  constructor(public value: Try<A>) { super() }
+
+  toString(): string {
+    return this.value.fold(
+      e => `IO.raise(${JSON.stringify(e)})`,
+      v => `IO.now(${JSON.stringify(v)})`
+    )
+  }
+}
+
+/**
+ * Reusable reference, to use in {@link IO.unit}.
+ *
+ * @private
+ */
+const ioUnitRef: IOPure<void> = new IOPure(Try.unit())
+
+/**
+ * `Once` is an internal `IO` state that executes the given `thunk`
+ * only once, upon calling `get()` and then memoize its result for
+ * subsequent invocations.
+ *
+ * Returned by [[IO.once]].
+ *
+ * @private
+ */
+class IOOnce<A> extends IO<A> {
+  readonly _funADType: "once" = "once"
+
+  private _thunk: () => A
+  public cache: Try<A>
+  public onlyOnSuccess: boolean
+
+  constructor(thunk: () => A, onlyOnSuccess: boolean) {
+    super()
+    this._thunk = thunk
+    this.onlyOnSuccess = onlyOnSuccess
+  }
+
+  runTry(): Try<A> {
+    if (this._thunk) {
+      const result = Try.of(this._thunk)
+      if (result.isSuccess() || !this.onlyOnSuccess) {
+        // GC purposes
+        delete this._thunk
+        delete this.onlyOnSuccess
+        this.cache = result
+      }
+      return result
+    }
+    return this.cache
+  }
+
+  toString(): string { return `IO.once([thunk])` }
+}
+
+/**
+ * `Always` is an internal `IO` state that executes the given `thunk`
+ * every time the call to `get()` happens. Returned by [[IO.always]].
+ *
+ * @private
+ */
+class IOAlways<A> extends IO<A> {
+  readonly _funADType: "always" = "always"
+
+  constructor(public thunk: () => A) { super() }
+  toString(): string { return `IO.always([thunk])` }
+}
+
+/**
+ * `FlatMap` is an internal `IO` state that represents a
+ * [[IO.flatMap .flatMap]], [[IO.map .map]], [[IO.transform .transform]]
+ * or a [[IO.transformWith .transformWith]] operation, all of them
+ * being expressed with this state.
+ *
+ * @private
+ */
+class IOFlatMap<A, B> extends IO<B> {
+  readonly _funADType: "flatMap" = "flatMap"
+
+  constructor(
+    public readonly source: IO<A>,
+    public readonly f: ((a: A) => IO<B>),
+    public readonly g?: ((e: Throwable) => IO<B>)) { super() }
+
+  toString(): string {
+    return `IOFlatMap(${String(this.source)}, ${this.f}, ${this.g})`
+  }
+}
+
+/**
+ * Type alias representing registration callbacks for tasks
+ * created with `asyncUnsafe`, that are going to get executed
+ * when the asynchronous task gets evaluated.
+ */
+export type IORegister<A> =
+  (context: IOContext, callback: (result: Try<A>) => void) => void
+
+/**
+ * Constructs a lazy [[IO]] instance whose result will
+ * be computed asynchronously.
+ *
+ * Unsafe to build directly, only use if you know what you're doing.
+ * For building `Async` instances safely, see {@link IO.async}.
+ *
+ * @private
+ * @hidden
+ */
+class IOAsync<A> extends IO<A> {
+  readonly _funADType: "async" = "async"
+
+  constructor(public readonly register: IORegister<A>) { super() }
+  toString(): string {
+    return `IO#Async([context], [function])`
+  }
+}
+
+/**
+ * The `Context` under which {@link IO} is supposed to be executed.
+ *
+ * This definition is of interest only when creating
+ * tasks with {@link IO.asyncUnsafe}, which exposes internals and
+ * is considered unsafe to use.
+ *
+ * @final
+ */
+export class IOContext {
+  /**
+   * The `Scheduler` in charge of evaluating asynchronous boundaries
+   * on `runAsync`.
+   */
+  public readonly scheduler: Scheduler
+
+  /**
+   * Is the `StackedCancelable` that accumulates cancelable
+   * actions, to be triggered if cancellation happens.
+   */
+  public readonly connection: StackedCancelable
+
+  /**
+   * Options passed to the run-loop implementation, determining
+   * its behavior. See {@link IOOptions} for the available
+   * options.
+   */
+  public readonly options: IOOptions
+
+  constructor(
+    scheduler: Scheduler,
+    connection: StackedCancelable = new StackedCancelable(),
+    options: IOOptions = { autoCancelableRunLoops: false }) {
+
+    this.scheduler = scheduler
+    this.options = options
+    this.connection = connection
+
+    // Enables auto-cancelable run-loops
+    if (options.autoCancelableRunLoops)
+      this.shouldCancel = () => connection.isCanceled()
+  }
+
+  /**
+   * Resets the stored `frameIndex`.
+   *
+   * Calling this method inside the logic of a {@link IO.asyncUnsafe}
+   * lets the run-loop know that an async boundary happened. This
+   * works in tandem with the logic for `ExecutionModel.batched(n)`,
+   * for better detection of synchronous cycles, to avoid introducing
+   * forced async boundaries where not needed.
+   */
+  markAsyncBoundary(): void {
+    this.scheduler.batchIndex = 0
+  }
+
+  /**
+   * Returns `true` in case the run-loop should be canceled,
+   * but this can only happen if `autoCancelableRunLoops` is
+   * set to `true`.
+   */
+  shouldCancel(): boolean { return false }
+}
+
+/**
+ * Set of options for customizing IO's behavior.
+ *
+ * @param autoCancelableRunLoops should be set to `true` in
+ *        case you want `flatMap` driven loops to be
+ *        auto-cancelable. Defaults to `false` because of
+ *        safety concerns.
+ */
+export type IOOptions = {
+  autoCancelableRunLoops: boolean
+}
+
+/** @hidden */
+type Current = IO<any>
+/** @hidden */
+type Bind = ((a: any) => IO<any>)
+/** @hidden */
+type BindT = Bind | [Bind, Bind]
+/** @hidden */
+type CallStack = Array<BindT>
+
+/** @hidden */
+function _ioPopNextBind(bFirst: BindT | null, bRest: CallStack | null): Bind | null {
+  let f: Bind | [Bind, Bind] | null | undefined = undefined
+  if (bFirst) f = bFirst
+  else if (bRest && bRest.length > 0) f = bRest.pop()
+  if (f) return typeof f === "function" ? f : f[0]
+  return null
+}
+
+/** @hidden */
+function _ioFindErrorHandler(bFirst: BindT | null, bRest: CallStack | null): Bind | null {
+  let cursor: any = bFirst
+  do {
+    if (cursor && typeof cursor !== "function") return cursor[1]
+    cursor = bRest ? bRest.pop() : null
+  } while (cursor)
+
+  return null
+}
+
+/**
+ * We need to build a callback on each cycle involving an `IOAsync`
+ * state. This class builds a mutable callback to reuse on each
+ * cycle in order to reduce GC pressure.
+ *
+ * @hidden
+ * @final
+ */
+class RestartCallback {
+  private canCall = false
+  private bFirst: BindT | null = null
+  private bRest: CallStack | null = null
+
+  public readonly asFunction: (result: Try<any>) => void
+
+  constructor(
+    private context: IOContext,
+    private callback: (r: Try<any>) => void) {
+
+    this.asFunction = this.signal.bind(this)
+  }
+
+  prepare(bFirst: BindT | null, bRest: CallStack | null) {
+    this.bFirst = bFirst
+    this.bRest = bRest
+    this.canCall = true
+  }
+
+  signal(result: Try<any>): void {
+    if (this.canCall) {
+      this.canCall = false
+      ioGenericRunLoop(
+        new IOPure(result),
+        this.context.scheduler,
+        this.context,
+        this.callback,
+        this,
+        this.bFirst,
+        this.bRest
+      )
+    } else if (result.isFailure()) {
+      this.context.scheduler.reportFailure(result.failed().get())
+    }
+  }
+}
+
+/** @hidden */
+function ioExecuteAsync(
+  register: IORegister<any>,
+  context: IOContext,
+  cb: (result: Try<any>) => void,
+  rcb: RestartCallback | null,
+  bFirst: BindT | null,
+  bRest: CallStack | null,
+  frameIndex: number) {
+
+  if (!context.shouldCancel()) {
+    context.scheduler.batchIndex = frameIndex
+
+    const restart = rcb || new RestartCallback(context, cb)
+    restart.prepare(bFirst, bRest)
+    register(context, restart.asFunction)
+  }
+}
+
+/** @hidden */
+function ioRestartAsync(
+  start: IO<any>,
+  context: IOContext,
+  cb: (result: Try<any>) => void,
+  rcb: RestartCallback | null,
+  bFirstInit: BindT | null,
+  bRestInit: CallStack | null): void {
+
+  if (!context.shouldCancel())
+    context.scheduler.executeAsync(() => {
+      ioGenericRunLoop(start, context.scheduler, context, cb, rcb, bFirstInit, bRestInit)
+    })
+}
+
+/** @hidden */
+function ioGenericRunLoop(
+  start: IO<any>,
+  scheduler: Scheduler,
+  context: IOContext | null,
+  cb: (result: Try<any>) => void,
+  rcb: RestartCallback | null,
+  bFirstInit: BindT | null,
+  bRestInit: CallStack | null): ICancelable | void {
+
+  let current: Current | Try<any> = start
+  let bFirst: BindT | null = bFirstInit
+  let bRest: CallStack | null = bRestInit
+
+  const modulus = scheduler.executionModel.recommendedBatchSize - 1
+  let frameIndex = scheduler.batchIndex
+
+  while (true) {
+    if (current instanceof Try) {
+      if (current.isSuccess()) {
+        const bind = _ioPopNextBind(bFirst, bRest)
+        if (!bind) { return cb(current) }
+
+        try {
+          current = bind(current.get())
+        } catch (e) {
+          current = Try.failure(e)
+        }
+      } else {
+        const bind = _ioFindErrorHandler(bFirst, bRest)
+        if (!bind) { return cb(current) }
+
+        try {
+          current = bind(current.failed().get())
+        } catch (e) {
+          current = Try.failure(e)
+        }
+      }
+
+      bFirst = null
+      const nextIndex = (frameIndex + 1) & modulus
+      // Should we force an asynchronous boundary?
+      if (nextIndex) {
+        frameIndex = nextIndex
+      } else {
+        const ctx = context || new IOContext(scheduler)
+        const boxed = current instanceof Try ? new IOPure(current) : current
+        ioRestartAsync(boxed, ctx, cb, rcb, bFirst, bRest)
+        return ctx.connection
+      }
+    }
+    else switch (current._funADType) {
+      case "pure":
+        current = (current as IOPure<any>).value
+        break
+
+      case "always":
+        current = Try.of((current as IOAlways<any>).thunk)
+        break
+
+      case "once":
+        current = (current as IOOnce<any>).runTry()
+        break
+
+      case "flatMap":
+        const flatM: IOFlatMap<any, any> = current as any
+        if (bFirst) {
+          if (!bRest) bRest = []
+          bRest.push(bFirst)
+        }
+
+        bFirst = !flatM.g ? flatM.f : [flatM.f, flatM.g]
+        current = flatM.source
+        break
+
+      case "async":
+        const async: IOAsync<any> = current as any
+        const ctx = context || new IOContext(scheduler)
+        ioExecuteAsync(async.register, ctx, cb, rcb, bFirst, bRest, frameIndex)
+        return ctx.connection
+    }
+  }
+}
+
+/** @hidden */
+function ioToFutureGoAsync(
+  start: IO<any>,
+  scheduler: Scheduler,
+  bFirst: BindT | null,
+  bRest: CallStack | null,
+  forcedAsync: boolean): Future<any> {
+
+  return Future.create<any>(cb => {
+    const conn = new StackedCancelable()
+    const ctx = new IOContext(scheduler, conn)
+
+    if (forcedAsync)
+      ioRestartAsync(start as any, ctx, cb as any, null, bFirst, bRest)
+    else
+      ioGenericRunLoop(start as any, scheduler, ctx, cb as any, null, bFirst, bRest)
+
+    return conn
+  })
+}
+
+/** @hidden */
+function taskToFutureRunLoop(
+  start: IO<any>,
+  scheduler: Scheduler): Future<any> {
+
+  let current: Current | Try<any> = start
+  let bFirst: BindT | null = null
+  let bRest: CallStack | null = null
+
+  const modulus = scheduler.executionModel.recommendedBatchSize - 1
+  let frameIndex = scheduler.batchIndex
+
+  while (true) {
+    if (current instanceof Try) {
+      if (current.isSuccess()) {
+        const bind = _ioPopNextBind(bFirst, bRest)
+        if (!bind) { return Future.pure(current.get()) }
+
+        try {
+          current = bind(current.get())
+        } catch (e) {
+          current = new IOPure(Try.failure(e))
+        }
+      } else {
+        const err = current.failed().get()
+        const bind = _ioFindErrorHandler(bFirst, bRest)
+        if (!bind) { return Future.raise(err) }
+
+        try {
+          current = bind(err)
+        } catch (e) {
+          current = new IOPure(Try.failure(e))
+        }
+      }
+
+      bFirst = null
+      const nextIndex = (frameIndex + 1) & modulus
+      // Should we force an asynchronous boundary?
+      if (nextIndex) {
+        frameIndex = nextIndex
+      } else {
+        return ioToFutureGoAsync(current, scheduler, bFirst, bRest, true)
+      }
+    }
+    else switch (current._funADType) {
+      case "pure":
+        current = (current as IOPure<any>).value
+        break
+
+      case "always":
+        current = Try.of((current as IOAlways<any>).thunk)
+        break
+
+      case "once":
+        current = (current as IOOnce<any>).runTry()
+        break
+
+      case "flatMap":
+        const flatM: IOFlatMap<any, any> = current as any
+        if (bFirst) {
+          if (!bRest) bRest = []
+          bRest.push(bFirst)
+        }
+
+        bFirst = !flatM.g ? flatM.f : [flatM.f, flatM.g]
+        current = flatM.source
+        break
+
+      case "async":
+        const async = current as IOAsync<any>
+        return ioToFutureGoAsync(async, scheduler, bFirst, bRest, false)
+    }
+  }
+}
+
+/**
+ * Internal utility used in the implementation of `IO.async`.
+ *
+ * @hidden
+ */
+function ioSafeCallback<A>(
+  ec: Scheduler,
+  conn: StackedCancelable,
+  cb: (r: Try<A>) => void): ((r: Try<A>) => void) {
+
+  let called = false
+  return (r: Try<A>) => {
+    if (!called) {
+      called = true
+      // Inserting a light async boundary, otherwise we can have
+      // stack overflow issues, but also ordering issues with
+      // StackedCancelable.push in IO.async!
+      ec.trampoline(() => {
+        conn.pop()
+        cb(r)
+      })
+    } else if (r.isFailure()) {
+      ec.reportFailure(r.failed().get())
+    }
+  }
+}

--- a/packages/funfix-effect/src/io.ts
+++ b/packages/funfix-effect/src/io.ts
@@ -463,12 +463,52 @@ export class IO<A> {
   }
 
   /**
+   * Sequentially compose two `IO` actions, discarding any value
+   * produced by the first.
+   *
+   * So this:
+   *
+   * ```typescript
+   * ioA.followedBy(ioB)
+   * ```
+   *
+   * Is equivalent with this:
+   *
+   * ```typescript
+   * ioA.flatMap(_ => fb)
+   * ```
+   */
+  followedBy<B>(fb: IO<B>): IO<B> {
+    return this.flatMap(_ => fb)
+  }
+
+  /**
    * Returns a new `IO` that upon evaluation will execute the given
    * function for the generated element, transforming the source into
    * an `IO<void>`.
    */
   forEach(cb: (a: A) => void): IO<void> {
     return this.map(cb)
+  }
+
+  /**
+   * Sequentially compose two actions, discarding any value
+   * produced by the second.
+   *
+   * So this:
+   *
+   * ```typescript
+   * ioA.forEffect(ioB)
+   * ```
+   *
+   * Is equivalent with this:
+   *
+   * ```typescript
+   * ioA.flatMap(a => ioB.map(_ => a))
+   * ```
+   */
+  forEffect<B>(fb: IO<B>): IO<A> {
+    return this.flatMap(a => fb.map(_ => a))
   }
 
   /**

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -71,6 +71,7 @@ const err1: IO<number> = IO.raise("Error!")
 
 const s1: IO<number> = IO.suspend(() => IO.pure(1))
 const s2: IO<number> = IO.defer(() => IO.pure(1))
+const s3: IO<number> = IO.deferAction((ec: Scheduler) => IO.pure(1))
 
 const rec: IO<string> = IO.tailRecM(10, (a: number) => {
   if (a <= 0)
@@ -103,3 +104,11 @@ const async3: IO<number> =
 
 const opt1: IO<number> = t1.executeWithOptions({ autoCancelableRunLoops: true })
 const c: ICancelable | void = IO.unsafeStart(opt1, new IOContext(ec), r => console.info(r.getOrElse(0)))
+
+const f: Future<number> = Future.pure(1)
+const ff1: IO<number> = IO.fromFuture(f)
+const ff2: IO<number> = IO.deferFuture(() => f)
+const ff3: IO<number> = IO.deferFutureAction((ec: Scheduler) => f)
+
+const mem1: IO<number> = ff1.memoize()
+const mem2: IO<number> = ff1.memoizeOnSuccess()

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -19,7 +19,7 @@
 
 import type { Throwable } from "funfix-core"
 import { Try, Either, Left, Right, Success } from "funfix-core"
-import { ICancelable, Future, Scheduler, StackedCancelable } from "funfix-exec"
+import { ICancelable, Future, Scheduler, StackedCancelable, ExecutionModel } from "funfix-exec"
 import { IO, IOContext } from "../../src/"
 
 const ec = Scheduler.global.get()
@@ -104,6 +104,7 @@ const async3: IO<number> =
 
 const opt1: IO<number> = t1.executeWithOptions({ autoCancelableRunLoops: true })
 const c: ICancelable | void = IO.unsafeStart(opt1, new IOContext(ec), r => console.info(r.getOrElse(0)))
+const em1: IO<number> = t1.executeWithModel(ExecutionModel.alwaysAsync())
 
 const f: Future<number> = Future.pure(1)
 const ff1: IO<number> = IO.fromFuture(f)
@@ -112,3 +113,13 @@ const ff3: IO<number> = IO.deferFutureAction((ec: Scheduler) => f)
 
 const mem1: IO<number> = ff1.memoize()
 const mem2: IO<number> = ff1.memoizeOnSuccess()
+
+const fork1: IO<number> = ff1.executeForked()
+const fork2: IO<number> = ff1.executeForked(ec)
+const fork3: IO<number> = IO.fork(ff1)
+const fork4: IO<number> = IO.fork(ff1, ec)
+
+const ab1: IO<number> = ff1.asyncBoundary()
+const ab2: IO<number> = ff1.asyncBoundary()
+const ab3: IO<number> = IO.shift().flatMap(_ => ff1)
+const ab4: IO<number> = IO.shift(ec).flatMap(_ => ff1)

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -19,7 +19,7 @@
 
 import type { Throwable } from "funfix-core"
 import { Try, Either, Left, Right, Success } from "funfix-core"
-import { ICancelable, Future, Scheduler, StackedCancelable, ExecutionModel } from "funfix-exec"
+import { ICancelable, Future, Scheduler, StackedCancelable, ExecutionModel, Duration } from "funfix-exec"
 import { IO, IOContext } from "../../src/"
 
 const ec = Scheduler.global.get()
@@ -54,7 +54,7 @@ const r3: IO<string | number> = t1.recover(e => String(e))
 const r4: IO<string | number> = t1.recoverWith(e => IO.now(String(e)))
 
 const at1: IO<Either<Throwable, number>> = t1.attempt()
-const fr1: IO<void> = t1.forEachL((x: number) => console.info(x))
+const fr1: IO<void> = t1.forEach((x: number) => console.info(x))
 
 const of1: IO<number> = IO.of(() => 1)
 const of2: IO<string> = IO.of(() => "Hello!")
@@ -123,3 +123,25 @@ const ab1: IO<number> = ff1.asyncBoundary()
 const ab2: IO<number> = ff1.asyncBoundary()
 const ab3: IO<number> = IO.shift().flatMap(_ => ff1)
 const ab4: IO<number> = IO.shift(ec).flatMap(_ => ff1)
+
+const mMap2: IO<number> = IO.map2(IO.pure(1), IO.pure(1), (a, b) => a + b)
+const mMap3: IO<number> = IO.map3(IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c) => a + b + c)
+const mMap4: IO<number> = IO.map4(IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c, d) => a + b + c + d)
+const mMap5: IO<number> = IO.map5(IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c, d, e) => a + b + c + d + e)
+const mMap6: IO<number> = IO.map6(IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c, d, e, f) => a + b + c + d + e + f)
+
+const pMap2: IO<number> = IO.parMap2(IO.pure(1), IO.pure(1), (a, b) => a + b)
+const pMap3: IO<number> = IO.parMap3(IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c) => a + b + c)
+const pMap4: IO<number> = IO.parMap4(IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c, d) => a + b + c + d)
+const pMap5: IO<number> = IO.parMap5(IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c, d, e) => a + b + c + d + e)
+const pMap6: IO<number> = IO.parMap6(IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), IO.pure(1), (a, b, c, d, e, f) => a + b + c + d + e + f)
+
+const arr: IO<number>[] = [IO.pure(1), IO.pure(2), IO.pure(3)]
+const sequence: IO<number[]> = IO.sequence(arr)
+const gather: IO<number[]> = IO.gather(arr)
+
+const delay1: IO<number> = ff1.delayResult(1000)
+const delay2: IO<number> = ff1.delayResult(Duration.of(1000))
+const delay3: IO<number> = ff1.delayExecution(1000)
+const delay4: IO<number> = ff1.delayExecution(Duration.of(1000))
+const delay5: IO<void> = IO.delayedTick(1000)

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import type { Throwable } from "funfix-core"
+import { Try, Either, Left, Right, Success } from "funfix-core"
+import { ICancelable, Future, Scheduler, StackedCancelable } from "funfix-exec"
+import { IO } from "../../src/"
+
+const t1: IO<number> = IO.now(1)
+
+const f1: Future<number> = t1.run()
+const f2: Future<number> = t1.run(Scheduler.global.get())
+const c1: ICancelable = t1.runOnComplete((r: Try<number>) => console.info(r.getOrElse(0)))
+const c2: ICancelable = t1.runOnComplete((r: Try<number>) => console.info(r.getOrElse(0)), Scheduler.global.get())
+
+const map1: IO<string> = t1.map(x => String(x))
+const map2: IO<number> = t1.map(x => x + 1)
+const map3: IO<IO<number>> = t1.map(x => IO.pure(x + 1))
+
+const fmap1: IO<string> = t1.flatMap(x => IO.now(String(x)))
+const fmap2: IO<number> = t1.flatMap(x => IO.now(x + 1))
+const fmap3: IO<IO<number>> = t1.flatMap(x => IO.now(IO.now(x + 1)))
+
+const chain1: IO<string> = t1.chain(x => IO.now(String(x)))
+const chain2: IO<number> = t1.chain(x => IO.now(x + 1))
+const chain3: IO<IO<number>> = t1.chain(x => IO.now(IO.now(x + 1)))
+
+const tr1: IO<string> = t1.transform(e => String(e), v => String(v))
+const tr2: IO<IO<number>> = t1.transform(e => IO.now(1), v => IO.now(v))
+const tr3: IO<number> = t1.transformWith(e => IO.now(1), v => IO.now(v))
+const tr4: IO<string | number> = t1.transform(e => String(e), v => v)
+const tr5: IO<string | number> = t1.transformWith(e => IO.now(String(e)), v => IO.pure(v))
+
+const r1: IO<number> = t1.recover(e => 0)
+const r2: IO<number> = t1.recoverWith(e => IO.now(0))
+const r3: IO<string | number> = t1.recover(e => String(e))
+const r4: IO<string | number> = t1.recoverWith(e => IO.now(String(e)))
+
+const at1: IO<Either<Throwable, number>> = t1.attempt()
+const fr1: IO<void> = t1.forEachL((x: number) => console.info(x))
+
+const of1: IO<number> = IO.of(() => 1)
+const of2: IO<string> = IO.of(() => "Hello!")
+const of3: IO<number> = IO.always(() => 1)
+const of4: IO<string> = IO.once(() => "Hello!")
+
+const pure1: IO<number> = IO.now(1)
+const pure2: IO<string> = IO.now("Hello!")
+const pure3: IO<number> = IO.pure(1)
+const pure4: IO<string> = IO.pure("Hello!")
+const pure5: IO<void> = IO.unit()
+
+const err1: IO<number> = IO.raise("Error!")
+
+const s1: IO<number> = IO.suspend(() => IO.pure(1))
+const s2: IO<number> = IO.defer(() => IO.pure(1))
+
+const rec: IO<string> = IO.tailRecM(10, (a: number) => {
+  if (a <= 0)
+    return IO.of(() => Left(a - 1))
+  else
+    return IO.pure(Right("Done!"))
+})
+
+const async1: IO<number> =
+  IO.asyncUnsafe((context, callback) => {
+    const ec: Scheduler = context.scheduler
+    const conn: StackedCancelable = context.connection
+
+    const task = ec.scheduleOnce(1000, () => {
+      conn.pop()
+      callback(Success(1))
+    })
+
+    conn.push(task)
+  })
+
+const async2: IO<number> =
+  IO.async((ec: Scheduler, cb) => cb(Success(1)))
+
+const async3: IO<number> =
+  IO.async((ec, cb) => {
+    const task: ICancelable = ec.scheduleOnce(10, () => cb(Success(1)))
+    return task
+  })

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -20,14 +20,15 @@
 import type { Throwable } from "funfix-core"
 import { Try, Either, Left, Right, Success } from "funfix-core"
 import { ICancelable, Future, Scheduler, StackedCancelable } from "funfix-exec"
-import { IO } from "../../src/"
+import { IO, IOContext } from "../../src/"
 
+const ec = Scheduler.global.get()
 const t1: IO<number> = IO.now(1)
 
 const f1: Future<number> = t1.run()
-const f2: Future<number> = t1.run(Scheduler.global.get())
+const f2: Future<number> = t1.run(ec)
 const c1: ICancelable = t1.runOnComplete((r: Try<number>) => console.info(r.getOrElse(0)))
-const c2: ICancelable = t1.runOnComplete((r: Try<number>) => console.info(r.getOrElse(0)), Scheduler.global.get())
+const c2: ICancelable = t1.runOnComplete((r: Try<number>) => console.info(r.getOrElse(0)), ec)
 
 const map1: IO<string> = t1.map(x => String(x))
 const map2: IO<number> = t1.map(x => x + 1)
@@ -99,3 +100,6 @@ const async3: IO<number> =
     const task: ICancelable = ec.scheduleOnce(10, () => cb(Success(1)))
     return task
   })
+
+const opt1: IO<number> = t1.executeWithOptions({ autoCancelableRunLoops: true })
+const c: ICancelable | void = IO.unsafeStart(opt1, new IOContext(ec), r => console.info(r.getOrElse(0)))

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -155,3 +155,6 @@ const time3: IO<number | string> = ff1.timeoutTo(1000, IO.pure("hello"))
 const time4: IO<number | string> = ff1.timeoutTo(Duration.of(1000), IO.pure("hello"))
 
 const firstOf1: IO<number> = IO.firstCompletedOf([IO.pure(1), IO.pure(2), IO.pure(3)])
+
+const flat1: IO<number> = IO.pure("Hello").followedBy(IO.pure(1))
+const flat2: IO<string> = IO.pure("Hello").forEffect(IO.pure(1))

--- a/packages/funfix-effect/test/flow/io.test.js.flow
+++ b/packages/funfix-effect/test/flow/io.test.js.flow
@@ -18,7 +18,7 @@
 /* @flow */
 
 import type { Throwable } from "funfix-core"
-import { Try, Either, Left, Right, Success } from "funfix-core"
+import { Try, Either, Left, Right, Success, Option } from "funfix-core"
 import { ICancelable, Future, Scheduler, StackedCancelable, ExecutionModel, Duration } from "funfix-exec"
 import { IO, IOContext } from "../../src/"
 
@@ -145,3 +145,13 @@ const delay2: IO<number> = ff1.delayResult(Duration.of(1000))
 const delay3: IO<number> = ff1.delayExecution(1000)
 const delay4: IO<number> = ff1.delayExecution(Duration.of(1000))
 const delay5: IO<void> = IO.delayedTick(1000)
+
+const do1: IO<number> = ff1.doOnFinish((e: Option<Throwable>) => IO.unit())
+const do2: IO<number> = ff1.doOnCancel(IO.pure())
+
+const time1: IO<number> = ff1.timeout(1000)
+const time2: IO<number> = ff1.timeout(Duration.of(1000))
+const time3: IO<number | string> = ff1.timeoutTo(1000, IO.pure("hello"))
+const time4: IO<number | string> = ff1.timeoutTo(Duration.of(1000), IO.pure("hello"))
+
+const firstOf1: IO<number> = IO.firstCompletedOf([IO.pure(1), IO.pure(2), IO.pure(3)])

--- a/packages/funfix-effect/test/ts/instances.ts
+++ b/packages/funfix-effect/test/ts/instances.ts
@@ -16,7 +16,8 @@
  */
 
 import * as jv from "jsverify"
-import { Eval } from "../../src/"
+import { Eval, IO } from "../../src/"
+import {Failure, Success} from "funfix-core";
 
 export const arbEval: jv.Arbitrary<Eval<number>> =
   jv.pair(jv.number, jv.number).smap(
@@ -37,4 +38,31 @@ export const arbEval: jv.Arbitrary<Eval<number>> =
       }
     },
     u => [u.get(), u.get()]
+  )
+
+export const arbIO: jv.Arbitrary<IO<number>> =
+  jv.pair(jv.number, jv.number).smap(
+    v => {
+      switch (v[0] % 9) {
+        case 0:
+          return IO.now(v[1])
+        case 1:
+          return IO.raise(v[1])
+        case 2:
+          return IO.always(() => v[1])
+        case 3:
+          return IO.once(() => v[1])
+        case 4:
+          return IO.suspend(() => IO.now(v[1]))
+        case 5:
+          return IO.async<number>((ec, cb) => cb(Success(v[1])))
+        case 6:
+          return IO.async<number>((ec, cb) => cb(Failure(v[1])))
+        case 7:
+          return IO.async<number>((ec, cb) => cb(Success(v[1]))).flatMap(IO.now)
+        default:
+          return IO.now(0).flatMap(_ => IO.now(v[1]))
+      }
+    },
+    u => [0, 0]
   )

--- a/packages/funfix-effect/test/ts/instances.ts
+++ b/packages/funfix-effect/test/ts/instances.ts
@@ -43,7 +43,7 @@ export const arbEval: jv.Arbitrary<Eval<number>> =
 export const arbIO: jv.Arbitrary<IO<number>> =
   jv.pair(jv.number, jv.number).smap(
     v => {
-      switch (v[0] % 9) {
+      switch (v[0] % 11) {
         case 0:
           return IO.now(v[1])
         case 1:
@@ -60,8 +60,12 @@ export const arbIO: jv.Arbitrary<IO<number>> =
           return IO.async<number>((ec, cb) => cb(Failure(v[1])))
         case 7:
           return IO.async<number>((ec, cb) => cb(Success(v[1]))).flatMap(IO.now)
-        default:
+        case 8:
           return IO.now(0).flatMap(_ => IO.now(v[1]))
+        case 9:
+          return IO.always(() => v[1]).memoizeOnSuccess()
+        default:
+          return IO.suspend(() => IO.pure(v[1])).memoize()
       }
     },
     u => [0, 0]

--- a/packages/funfix-effect/test/ts/io.test.ts
+++ b/packages/funfix-effect/test/ts/io.test.ts
@@ -623,6 +623,26 @@ describe("IO aliases", () => {
       return f1.value().equals(f2.value())
     })
 
+  jv.property("fa.followedBy(fb) <-> fa.flatMap(_ => fb)",
+    inst.arbIO, inst.arbIO,
+    (fa, fb) => {
+      const ec = scheduler()
+      const f1 = fa.followedBy(fb).run(ec)
+      const f2 = fa.flatMap(_ => fb).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+
+  jv.property("fa.forEffect(fb) <-> fa.flatMap(a => fb.map(_ => a))",
+    inst.arbIO, inst.arbIO,
+    (fa, fb) => {
+      const ec = scheduler()
+      const f1 = fa.forEffect(fb).run(ec)
+      const f2 = fa.flatMap(a => fb.map(_ => a)).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+
   jv.property("of(f) <-> always(f)",
     jv.fun(jv.number),
     (f) => {

--- a/packages/funfix-effect/test/ts/io.test.ts
+++ b/packages/funfix-effect/test/ts/io.test.ts
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as jv from "jsverify"
+import * as inst from "./instances"
+import * as assert from "./asserts"
+
+import {
+  is, id,
+  Try,
+  Success,
+  Failure,
+  Left,
+  Right,
+  DummyError,
+  IllegalStateError,
+  Some, None, Option
+} from "funfix-core"
+
+import { TestScheduler, Future, ExecutionModel } from "funfix-exec"
+import { IO } from "../../src/"
+
+describe("IOPure", () => {
+  it("evaluates IO.pure(v).run() to Future.pure(v)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = IO.pure(1)
+    assert.equal(io.run().value(), Some(Success(1)))
+  })
+
+  it("evaluates IO.raise(e).run() to Future.raise(e)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = IO.raise("dummy")
+    assert.equal(io.run().value(), Some(Failure("dummy")))
+  })
+
+  it("evaluates IO.pure(v).runOnComplete()", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    let result: Option<Try<number>> = None
+    IO.pure(1).runOnComplete(r => { result = Some(r as any) })
+    assert.equal(result, Some(Success(1)))
+  })
+
+  it("evaluates IO.raise(e).runOnComplete()", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    let result: Option<Try<number>> = None
+    IO.raise("error").runOnComplete(r => { result = Some(r as any) })
+    assert.equal(result, Some(Failure("error")))
+  })
+
+  it("is stack safe in flatMap shallow loop", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = flatShallowLoop(10000, x => IO.pure(x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in flatMap eager loop", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = flatEagerLoop(2000, x => IO.pure(x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in suspend loop", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = suspendLoop(10000, x => IO.pure(x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+})
+
+describe("IO.always", () => {
+  it("is stack safe in flatMap shallow loop", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = flatShallowLoop(10000, x => IO.always(() => x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in flatMap eager loop", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = flatEagerLoop(2000, x => IO.always(() => x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in suspend loop", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = suspendLoop(10000, x => IO.always(() => x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+})
+
+describe("IO.once", () => {
+  let ec: TestScheduler
+
+  before(() => {
+    ec = new TestScheduler(undefined, ExecutionModel.global.get())
+  })
+
+  it("is stack safe in flatMap shallow loop", () => {
+    const io = flatShallowLoop(10000, x => IO.once(() => x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in flatMap eager loop", () => {
+    const io = flatEagerLoop(2000, x => IO.once(() => x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in suspend loop", () => {
+    const io = suspendLoop(10000, x => IO.once(() => x))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+})
+
+describe("IO.async", () => {
+  let ec: TestScheduler
+
+  before(() => {
+    ec = new TestScheduler(undefined, ExecutionModel.global.get())
+  })
+
+  it("is stack safe in flatMap shallow loop", () => {
+    const io = flatShallowLoop(10000, x => IO.async<number>((ec, cb) => cb(Success(x))))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in flatMap eager loop", () => {
+    const io = flatEagerLoop(2000, x => IO.async<number>((ec, cb) => cb(Success(x))))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("is stack safe in suspend loop", () => {
+    const io = suspendLoop(10000, x => IO.async<number>((ec, cb) => cb(Success(x))))
+    const f = io.run(ec)
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("protects against multiple callback calls", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("dummy")
+
+    const io = IO.async((ec, cb) => {
+      cb(Success(1))
+      cb(Success(2))
+      cb(Failure(dummy))
+    })
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Success(1)))
+    assert.ok(ec.triggeredFailures().length > 0)
+    assert.equal(ec.triggeredFailures()[0], dummy)
+  })
+
+  it("protects against user error", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("registration1")
+    const io = IO.async((ec, cb) => { throw dummy })
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Failure(dummy)))
+  })
+
+  it("reports error in registration after callback was called", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("registration2")
+    const io = IO.async<number>((ec, cb) => { cb(Success(1)); throw dummy })
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Success(1)))
+    assert.ok(ec.triggeredFailures().length > 0)
+    assert.equal(ec.triggeredFailures()[0].message, dummy.message)
+  })
+})
+
+describe("IO", () => {
+  it("recovers from failure with run()", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = IO.raise<number>("error").recoverWith(e => {
+      if (e === "error") return IO.pure(100)
+      return IO.raise(e)
+    })
+
+    const f = io.run(ec)
+    ec.tick()
+    assert.equal(f.value(), Some(Success(100)))
+  })
+
+  it("recovers from failure with runOnComplete()", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const io = IO.raise<number>("error").recoverWith(e => {
+      if (e === "error") return IO.pure(100)
+      return IO.raise(e)
+    })
+
+    let result: Option<Try<number>> = None
+    io.runOnComplete((r: Try<number>) => { result = Some(r) })
+
+    ec.tick()
+    assert.equal(result, Some(Success(100)))
+  })
+
+  it("protects flatMap against user error (run)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("dummy")
+    const io = IO.pure(1).flatMap(_ => { throw dummy })
+    const f = io.run(ec)
+
+    ec.tick()
+    assert.equal(f.value(), Some(Failure(dummy)))
+  })
+
+  it("protects flatMap against user error (runOnComplete)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("dummy")
+    const io = IO.pure(1).flatMap(_ => { throw dummy })
+
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+
+    ec.tick()
+    assert.equal(result, Some(Failure(dummy)))
+  })
+
+  it("recovers from user error in flatMap (run)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("dummy")
+    const io = IO.pure(1).flatMap(_ => { throw dummy })
+      .recoverWith(e => {
+        if (e === dummy) return IO.pure(100)
+        return IO.raise(e)
+      })
+
+    const f = io.run(ec)
+
+    ec.tick()
+    assert.equal(f.value(), Some(Success(100)))
+  })
+
+  it("recovers from user error in flatMap (runOnComplete)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy = new DummyError("dummy")
+    const io = IO.pure(1).flatMap(_ => { throw dummy })
+      .recoverWith(e => {
+        if (e === dummy) return IO.pure(100)
+        return IO.raise(e)
+      })
+
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+
+    ec.tick()
+    assert.equal(result, Some(Success(100)))
+  })
+
+  it("protects against user errors in recoverWith (run)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy1 = new DummyError("dummy1")
+    const dummy2 = new DummyError("dummy2")
+
+    const io = IO.raise<number>(dummy1)
+      .recoverWith(_ => { throw dummy2 })
+      .recoverWith(e => {
+        return IO.pure(100)
+        // return IO.raise(e)
+      })
+
+    const f = io.run(ec)
+    ec.tick()
+    assert.equal(f.value(), Some(Success(100)))
+  })
+
+  it("protects against user errors in recoverWith (runOnComplete)", () => {
+    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const dummy1 = new DummyError("dummy1")
+    const dummy2 = new DummyError("dummy2")
+
+    const io = IO.raise<number>(dummy1).recoverWith(_ => { throw dummy2 })
+      .recoverWith(e => {
+        if (e === dummy2) return IO.pure(100)
+        return IO.raise(e)
+      })
+
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+
+    ec.tick()
+    assert.equal(result, Some(Success(100)))
+  })
+})
+
+function flatShallowLoop(n: number, f: (x: number) => IO<number>): IO<number> {
+  return f(n).flatMap(n => {
+    if (n <= 0) return IO.pure(n)
+    return flatShallowLoop(n - 1, f)
+  })
+}
+
+function flatEagerLoop(n: number, f: (x: number) => IO<number>): IO<number> {
+  let cursor = f(n)
+  for (let i = n - 1; i >= 0; i--) cursor = cursor.flatMap(x => f(x - 1))
+  return cursor
+}
+
+function suspendLoop(n: number, f: (x: number) => IO<number>): IO<number> {
+  return IO.suspend(() => {
+    if (n <= 0) return IO.pure(n)
+    return suspendLoop(n - 1, f)
+  })
+}

--- a/packages/funfix-effect/test/ts/io.test.ts
+++ b/packages/funfix-effect/test/ts/io.test.ts
@@ -20,14 +20,12 @@ import * as inst from "./instances"
 import * as assert from "./asserts"
 
 import {
-  is, id,
   Try,
   Success,
   Failure,
   Left,
   Right,
   DummyError,
-  IllegalStateError,
   Some, None, Option
 } from "funfix-core"
 
@@ -36,33 +34,29 @@ import { IO } from "../../src/"
 
 describe("IOPure", () => {
   it("evaluates IO.pure(v).run() to Future.pure(v)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
     const io = IO.pure(1)
     assert.equal(io.run().value(), Some(Success(1)))
   })
 
   it("evaluates IO.raise(e).run() to Future.raise(e)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
     const io = IO.raise("dummy")
     assert.equal(io.run().value(), Some(Failure("dummy")))
   })
 
   it("evaluates IO.pure(v).runOnComplete()", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
     let result: Option<Try<number>> = None
     IO.pure(1).runOnComplete(r => { result = Some(r as any) })
     assert.equal(result, Some(Success(1)))
   })
 
   it("evaluates IO.raise(e).runOnComplete()", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
     let result: Option<Try<number>> = None
     IO.raise("error").runOnComplete(r => { result = Some(r as any) })
     assert.equal(result, Some(Failure("error")))
   })
 
-  it("is stack safe in flatMap shallow loop", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+  it("is stack safe in flatMap shallow loop (run)", () => {
+    const ec = scheduler()
     const io = flatShallowLoop(10000, x => IO.pure(x))
     const f = io.run(ec)
 
@@ -70,8 +64,18 @@ describe("IOPure", () => {
     assert.equal(f.value(), Some(Success(0)))
   })
 
-  it("is stack safe in flatMap eager loop", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+  it("is stack safe in flatMap shallow loop (runOnComplete)", () => {
+    const ec = scheduler()
+    const io = flatShallowLoop(5000, x => IO.pure(x))
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+
+    assert.equal(result, None); ec.tick()
+    assert.equal(result, Some(Success(0)))
+  })
+
+  it("is stack safe in flatMap eager loop (run)", () => {
+    const ec = scheduler()
     const io = flatEagerLoop(2000, x => IO.pure(x))
     const f = io.run(ec)
 
@@ -79,8 +83,18 @@ describe("IOPure", () => {
     assert.equal(f.value(), Some(Success(0)))
   })
 
+  it("is stack safe in flatMap eager loop (runOnComplete)", () => {
+    const ec = scheduler()
+    const io = flatEagerLoop(5000, x => IO.pure(x))
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+
+    assert.equal(result, None); ec.tick()
+    assert.equal(result, Some(Success(0)))
+  })
+
   it("is stack safe in suspend loop", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const io = suspendLoop(10000, x => IO.pure(x))
     const f = io.run(ec)
 
@@ -91,7 +105,7 @@ describe("IOPure", () => {
 
 describe("IO.always", () => {
   it("is stack safe in flatMap shallow loop", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const io = flatShallowLoop(10000, x => IO.always(() => x))
     const f = io.run(ec)
 
@@ -100,7 +114,7 @@ describe("IO.always", () => {
   })
 
   it("is stack safe in flatMap eager loop", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const io = flatEagerLoop(2000, x => IO.always(() => x))
     const f = io.run(ec)
 
@@ -109,7 +123,7 @@ describe("IO.always", () => {
   })
 
   it("is stack safe in suspend loop", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const io = suspendLoop(10000, x => IO.always(() => x))
     const f = io.run(ec)
 
@@ -122,7 +136,7 @@ describe("IO.once", () => {
   let ec: TestScheduler
 
   before(() => {
-    ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    ec = scheduler()
   })
 
   it("is stack safe in flatMap shallow loop", () => {
@@ -154,7 +168,7 @@ describe("IO.async", () => {
   let ec: TestScheduler
 
   before(() => {
-    ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    ec = scheduler()
   })
 
   it("is stack safe in flatMap shallow loop", () => {
@@ -182,7 +196,7 @@ describe("IO.async", () => {
   })
 
   it("protects against multiple callback calls", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("dummy")
 
     const io = IO.async((ec, cb) => {
@@ -198,7 +212,7 @@ describe("IO.async", () => {
   })
 
   it("protects against user error", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("registration1")
     const io = IO.async((ec, cb) => { throw dummy })
 
@@ -207,7 +221,7 @@ describe("IO.async", () => {
   })
 
   it("reports error in registration after callback was called", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("registration2")
     const io = IO.async<number>((ec, cb) => { cb(Success(1)); throw dummy })
 
@@ -218,9 +232,16 @@ describe("IO.async", () => {
   })
 })
 
-describe("IO", () => {
+describe("IO (error recovery)", () => {
+  it("protects against errors in map", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.pure(1).map(x => { throw dummy })
+    assert.equal(io.run(ec).value(), Some(Failure(dummy)))
+  })
+
   it("recovers from failure with run()", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const io = IO.raise<number>("error").recoverWith(e => {
       if (e === "error") return IO.pure(100)
       return IO.raise(e)
@@ -232,7 +253,7 @@ describe("IO", () => {
   })
 
   it("recovers from failure with runOnComplete()", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const io = IO.raise<number>("error").recoverWith(e => {
       if (e === "error") return IO.pure(100)
       return IO.raise(e)
@@ -246,7 +267,7 @@ describe("IO", () => {
   })
 
   it("protects flatMap against user error (run)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("dummy")
     const io = IO.pure(1).flatMap(_ => { throw dummy })
     const f = io.run(ec)
@@ -256,7 +277,7 @@ describe("IO", () => {
   })
 
   it("protects flatMap against user error (runOnComplete)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("dummy")
     const io = IO.pure(1).flatMap(_ => { throw dummy })
 
@@ -268,7 +289,7 @@ describe("IO", () => {
   })
 
   it("recovers from user error in flatMap (run)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("dummy")
     const io = IO.pure(1).flatMap(_ => { throw dummy })
       .recoverWith(e => {
@@ -283,7 +304,7 @@ describe("IO", () => {
   })
 
   it("recovers from user error in flatMap (runOnComplete)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy = new DummyError("dummy")
     const io = IO.pure(1).flatMap(_ => { throw dummy })
       .recoverWith(e => {
@@ -299,7 +320,7 @@ describe("IO", () => {
   })
 
   it("protects against user errors in recoverWith (run)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy1 = new DummyError("dummy1")
     const dummy2 = new DummyError("dummy2")
 
@@ -316,7 +337,7 @@ describe("IO", () => {
   })
 
   it("protects against user errors in recoverWith (runOnComplete)", () => {
-    const ec = new TestScheduler(undefined, ExecutionModel.global.get())
+    const ec = scheduler()
     const dummy1 = new DummyError("dummy1")
     const dummy2 = new DummyError("dummy2")
 
@@ -332,7 +353,448 @@ describe("IO", () => {
     ec.tick()
     assert.equal(result, Some(Success(100)))
   })
+
+  it("recovers with recover", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.raise<number>(dummy).recover(e => e === dummy ? 10 : 0)
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Success(10)))
+  })
+
+  it("recovers with transform", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.raise<number>(dummy).transform(
+      e => e === dummy ? 10 : 0,
+      v => v + 1
+    )
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Success(10)))
+  })
+
+  it("recovers with transformWith", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.raise<number>(dummy).transformWith(
+      e => e === dummy ? IO.pure(10) : IO.raise(e),
+      v => IO.pure(v + 1)
+    )
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Success(10)))
+  })
+
+  it("returns Left on IO.raise", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const f = IO.raise(dummy).attempt().run(ec)
+    assert.equal(f.value(), Some(Success(Left(dummy))))
+  })
+
+  it("returns Right on success", () => {
+    const ec = scheduler()
+    const f = IO.pure(1).attempt().run(ec)
+    assert.equal(f.value(), Some(Success(Right(1))))
+  })
+
+  it("reports errors during async boundaries", () => {
+    const ec = scheduler()
+
+    const io = IO.asyncUnsafe((ctx, cb) => {
+      cb(Failure("dummy1"))
+      cb(Failure("dummy2"))
+      cb(Success(1))
+      cb(Failure("dummy3"))
+    })
+
+    const f = io.run(ec); ec.tick()
+    assert.equal(f.value(), Some(Failure("dummy1")))
+    assert.equal(ec.triggeredFailures().length, 2)
+    assert.equal(ec.triggeredFailures()[0], "dummy2")
+    assert.equal(ec.triggeredFailures()[1], "dummy3")
+  })
 })
+
+describe("IO.map", () => {
+  it("works", () => {
+    const ec = scheduler()
+    const io = IO.pure(1).map(x => x + 1)
+    assert.equal(io.run(ec).value(), Some(Success(2)))
+  })
+
+  it("protects against user error", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.pure(1).map(_ => { throw dummy })
+    assert.equal(io.run(ec).value(), Some(Failure(dummy)))
+  })
+
+  it("does forEach", () => {
+    const ec = scheduler()
+    let effect = 0
+
+    const io = IO.pure(10).forEach(x => { effect += x })
+    assert.equal(effect, 0)
+
+    io.run(ec); ec.tick()
+    assert.equal(effect, 10)
+  })
+
+  jv.property("map(f) <-> flatMap(x => pure(f(x)))",
+    inst.arbIO, jv.fun(jv.number),
+    (fa, f) => {
+      const ec = scheduler()
+      const f1 = fa.map(f).run(ec)
+      const f2 = fa.flatMap(x => IO.pure(f(x))).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+
+  jv.property("map(f) <-> transform(_, f)",
+    inst.arbIO, jv.fun(jv.number),
+    (fa, f) => {
+      const ec = scheduler()
+      const f1 = fa.map(f).run(ec)
+      const f2 = fa.transform(e => { throw e }, f).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+})
+
+describe("IO.tailRecM", () => {
+  it("is stack safe", () => {
+    const ec = scheduler()
+    const fa = IO.tailRecM(0, a => IO.now(a < 1000 ? Left(a + 1) : Right(a)))
+    const fu = fa.run(ec)
+    ec.tick()
+    assert.equal(fu.value(), Some(Success(1000)))
+  })
+
+  it("returns the failure unchanged", () => {
+    const ec = scheduler()
+    const fa = IO.tailRecM(0, a => IO.raise("failure"))
+    const fu = fa.run(ec)
+    ec.tick()
+    assert.equal(fu.value(), Some(Failure("failure")))
+  })
+
+  it("protects against user errors", () => {
+    const ec = scheduler()
+    // tslint:disable:no-string-throw
+    const fa = IO.tailRecM(0, a => { throw "dummy" })
+    const fu = fa.run(ec)
+    assert.equal(fu.value(), Some(Failure("dummy")))
+  })
+})
+
+describe("IO builders", () => {
+  it("always repeats side effects", () => {
+    const ec = scheduler()
+    let effect = 0
+
+    const io = IO.always(() => { effect += 1; return effect })
+
+    const f1 = io.run(ec); ec.tick()
+    assert.equal(f1.value(), Some(Success(1)))
+    const f2 = io.run(ec); ec.tick()
+    assert.equal(f2.value(), Some(Success(2)))
+  })
+
+  it("always protects against user error", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.always(() => { throw dummy })
+    assert.equal(io.run(ec).value(), Some(Failure(dummy)))
+  })
+
+  it("once does memoization", () => {
+    const ec = scheduler()
+    let effect = 0
+
+    const io = IO.once(() => { effect += 1; return effect })
+
+    const f1 = io.run(ec); ec.tick()
+    assert.equal(f1.value(), Some(Success(1)))
+    const f2 = io.run(ec); ec.tick()
+    assert.equal(f2.value(), Some(Success(1)))
+  })
+
+  it("once protects against user error", () => {
+    const ec = scheduler()
+    const dummy = new DummyError("dummy")
+    const io = IO.once(() => { throw dummy })
+    assert.equal(io.run(ec).value(), Some(Failure(dummy)))
+  })
+
+  it("IO.fromTry(Success(1)) <-> IO.pure(1)", () => {
+    const ec = scheduler()
+    assert.equal(IO.fromTry(Success(1)).run(ec).value(), Some(Success(1)))
+  })
+
+  it("IO.fromTry(Failure(e)) <-> IO.raise(e)", () => {
+    const ec = scheduler()
+    assert.equal(IO.fromTry(Failure("error")).run(ec).value(), Some(Failure("error")))
+  })
+})
+
+describe("IO aliases", () => {
+  jv.property("chain(f) <-> flatMap(f)",
+    inst.arbIO, jv.fun(inst.arbIO),
+    (fa, f) => {
+      const ec = scheduler()
+      const f1 = fa.flatMap(f).run(ec)
+      const f2 = fa.chain(f).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+
+  jv.property("of(f) <-> always(f)",
+    jv.fun(jv.number),
+    (f) => {
+      const ec = scheduler()
+      const f1 = IO.of(() => f(null)).run(ec)
+      const f2 = IO.always(() => f(null)).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+
+  jv.property("suspend(f) <-> unit.flatMap(_ => f())",
+    inst.arbIO,
+    (fa) => {
+      const ec = scheduler()
+      const f1 = IO.suspend(() => fa).run(ec)
+      const f2 = IO.unit().flatMap(_ => fa).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+
+  jv.property("defer(f) <-> unit.flatMap(_ => f())",
+    inst.arbIO,
+    (fa) => {
+      const ec = scheduler()
+      const f1 = IO.defer(() => fa).run(ec)
+      const f2 = IO.unit().flatMap(_ => fa).run(ec)
+      ec.tick()
+      return f1.value().equals(f2.value())
+    })
+})
+
+describe("IO run-loop", () => {
+  it("does processing in batches (run)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.batched())
+    let effect = 0
+
+    const io = flatShallowLoop(1000, x => IO.of(() => {
+      effect += 1
+      return x
+    }))
+
+    const f = io.run(ec)
+    assert.equal(effect, 128)
+    ec.tickOne()
+    assert.equal(effect, 256)
+    ec.tick()
+    assert.equal(effect, 1001)
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("does processing in batches (runOnComplete)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.batched())
+    let effect = 0
+
+    const io = flatShallowLoop(1000, x => IO.of(() => {
+      effect += 1
+      return x
+    }))
+
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+    assert.equal(effect, 128)
+
+    ec.tickOne()
+    assert.equal(effect, 256)
+
+    ec.tick()
+    assert.equal(effect, 1001)
+    assert.equal(result, Some(Success(0)))
+  })
+
+  it("can be auto-cancelable (run)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.batched())
+    let effect = 0
+
+    const io = flatShallowLoop(1000, x => IO.of(() => {
+      effect += 1
+      return x
+    }))
+
+    const f = io
+      .executeWithOptions({ autoCancelableRunLoops: true })
+      .run(ec)
+
+    assert.equal(effect, 128)
+    f.cancel()
+
+    ec.tick()
+    assert.equal(effect, 256)
+    assert.not(ec.hasTasksLeft())
+    assert.equal(f.value(), None)
+  })
+
+  it("can be auto-cancelable (runOnComplete)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.batched())
+    let effect = 0
+
+    const io = flatShallowLoop(1000, x => IO.of(() => {
+      effect += 1
+      return x
+    }))
+
+    let result: Option<Try<any>> = None
+    const c = io
+      .executeWithOptions({ autoCancelableRunLoops: true })
+      .runOnComplete((r: any) => { result = r }, ec)
+
+    assert.equal(effect, 128)
+    c.cancel()
+
+    ec.tick()
+    assert.equal(effect, 256)
+    assert.not(ec.hasTasksLeft())
+    assert.equal(result, None)
+  })
+
+  it("can auto-cancel at any async boundary (run)", () => {
+    const ec = scheduler()
+    const io = IO.asyncUnsafe<number>((ctx, cb) => {
+      ctx.scheduler.executeAsync(() => cb(Success(1)))
+    })
+
+    const f = io.flatMap(_ => io).executeWithOptions({ autoCancelableRunLoops: true }).run(ec)
+    f.cancel()
+
+    assert.equal(f.value(), None); ec.tick()
+    assert.equal(f.value(), None)
+    assert.not(ec.hasTasksLeft())
+  })
+
+  it("can auto-cancel at any async boundary (runOnComplete)", () => {
+    const ec = scheduler()
+    const io = IO.asyncUnsafe<number>((ctx, cb) => {
+      ctx.scheduler.executeAsync(() => cb(Success(1)))
+    })
+
+    let result: Option<Try<any>> = None
+    const c = io
+      .executeWithOptions({ autoCancelableRunLoops: true })
+      .runOnComplete(r => { result = Some(r) })
+
+    c.cancel()
+    ec.tick()
+    assert.equal(result, None)
+    assert.not(ec.hasTasksLeft())
+  })
+
+  it("process pure(n).map(f) in alwaysAsync mode (run)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.alwaysAsync())
+    const f = IO.pure(1).map(x => x + 1).run(ec)
+
+    assert.equal(f.value(), None); ec.tickOne()
+    assert.equal(f.value(), Some(Success(2)))
+  })
+
+  it("process pure(n).map(f) in alwaysAsync mode (runOnComplete)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.alwaysAsync())
+    let result: Option<Try<any>> = None
+    IO.pure(1).map(x => x + 1).runOnComplete(r => { result = Some(r) }, ec)
+
+    assert.equal(result, None); ec.tickOne()
+    assert.equal(result, Some(Success(2)))
+  })
+
+  it("can process in alwaysAsync mode (run)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.alwaysAsync())
+    let effect = 0
+
+    const io = flatShallowLoop(1000, x => IO.of(() => {
+      effect += 1
+      return x
+    }))
+
+    const f = io.run(ec)
+    assert.equal(effect, 1)
+
+    ec.tickOne()
+    assert.equal(effect, 2)
+    ec.tickOne()
+    assert.equal(effect, 3)
+
+    ec.tick()
+    assert.equal(effect, 1001)
+    assert.equal(f.value(), Some(Success(0)))
+  })
+
+  it("can process in alwaysAsync mode (runOnComplete)", () => {
+    const ec = scheduler().withExecutionModel(ExecutionModel.alwaysAsync())
+    let effect = 0
+
+    const io = flatShallowLoop(1000, x => IO.of(() => {
+      effect += 1
+      return x
+    }))
+
+    let result: Option<Try<any>> = None
+    io.runOnComplete(r => { result = Some(r) }, ec)
+    assert.equal(effect, 1)
+
+    ec.tickOne()
+    assert.equal(effect, 2)
+    ec.tickOne()
+    assert.equal(effect, 3)
+
+    ec.tick()
+    assert.equal(effect, 1001)
+    assert.equal(result, Some(Success(0)))
+  })
+
+  it("can mark async boundary (run)", () => {
+    const asyncEC = scheduler()
+
+    function signal(n: number): IO<number> {
+      return IO.asyncUnsafe<number>((ctx, cb) => {
+        asyncEC.executeAsync(() => {
+          ctx.markAsyncBoundary()
+          cb(Success(n))
+        })
+      })
+    }
+
+    const ec1 = scheduler().withExecutionModel(ExecutionModel.batched())
+    const f1 = Future.unit(ec1).flatMap(Future.pure)
+      .flatMap(_ => IO.pure(1).flatMap(IO.pure).run(ec1))
+      .map(_ => ec1.batchIndex)
+
+    ec1.tick()
+    asyncEC.tick()
+    assert.equal(f1.value(), Some(Success(4)))
+
+    const ec2 = scheduler()
+    const f2 = Future.unit(ec2).flatMap(Future.pure)
+      .flatMap(_ => IO.pure(1).flatMap(signal).run(ec2))
+      .map(_ => ec2.batchIndex)
+
+    ec2.tick()
+    asyncEC.tick()
+    assert.equal(f2.value(), Some(Success(1)))
+  })
+})
+
+function scheduler(): TestScheduler {
+  return new TestScheduler(undefined, ExecutionModel.global.get())
+}
 
 function flatShallowLoop(n: number, f: (x: number) => IO<number>): IO<number> {
   return f(n).flatMap(n => {

--- a/packages/funfix-effect/tslint.json
+++ b/packages/funfix-effect/tslint.json
@@ -15,6 +15,8 @@
     "quotemark": [true, "double", "avoid-escape"],
     "curly": false,
     "ter-indent": false,
-    "no-unused-variable": false
+    "no-unused-variable": false,
+    "brace-style": false,
+    "one-line": false
   }
 }

--- a/packages/funfix-exec/src/cancelable.js.flow
+++ b/packages/funfix-exec/src/cancelable.js.flow
@@ -76,3 +76,16 @@ declare export class SingleAssignCancelable extends AssignCancelable {
   static of(cb: () => void): SingleAssignCancelable;
   static empty(): SingleAssignCancelable;
 }
+
+declare export class StackedCancelable {
+  constructor(initial?: ICancelable[]): StackedCancelable;
+
+  isCanceled(): boolean;
+  cancel(): void;
+
+  push(value: ICancelable): this;
+  pop(): ICancelable;
+
+  static empty(): StackedCancelable;
+  static collection(...refs: Array<ICancelable>): StackedCancelable;
+}

--- a/packages/funfix-exec/src/index.ts
+++ b/packages/funfix-exec/src/index.ts
@@ -20,3 +20,6 @@ export * from "./time"
 export * from "./scheduler"
 export * from "./ref"
 export * from "./future"
+
+import * as execInternals from "./internals"
+export { execInternals }

--- a/packages/funfix-exec/src/internals.ts
+++ b/packages/funfix-exec/src/internals.ts
@@ -98,7 +98,7 @@ export const maxPowerOf2: number = 1 << 30
  *
  * @return an integer that is a power of 2, that is bigger or
  *        equal with our argument and that is "closest" to it.
- * 
+ *
  * @hidden
  */
 export function nextPowerOf2(nr: number): number {

--- a/packages/funfix-exec/src/internals.ts
+++ b/packages/funfix-exec/src/internals.ts
@@ -52,7 +52,7 @@ export function arrayBSearchInsertPos<A>(array: Array<A>, f: (a: A) => number):
 /**
  * Internal utility that builds an iterator out of an `Iterable` or an `Array`.
  *
- * @Hidden
+ * @hidden
  */
 export function iterableToArray<A>(values: Iterable<A>): A[] {
   if (!values) return []
@@ -69,12 +69,16 @@ export function iterableToArray<A>(values: Iterable<A>): A[] {
   }
 }
 
-/** Natural log of 2 */
+/**
+ * Natural log of 2.
+ * @hidden
+ */
 export const lnOf2 = Math.log(2)
 
 /**
  * Calculates the base 2 logarithm of the given argument.
  *
+ * @hidden
  * @return a number such that 2^nr^ is equal to our argument.
  */
 export function log2(x: number): number {
@@ -83,6 +87,7 @@ export function log2(x: number): number {
 
 /**
  * The maximum number that can be returned by {@link nextPowerOf2}.
+ * @hidden
  */
 export const maxPowerOf2: number = 1 << 30
 
@@ -93,6 +98,8 @@ export const maxPowerOf2: number = 1 << 30
  *
  * @return an integer that is a power of 2, that is bigger or
  *        equal with our argument and that is "closest" to it.
+ * 
+ * @hidden
  */
 export function nextPowerOf2(nr: number): number {
   if (nr < 0) throw new IllegalArgumentError("nr must be positive")

--- a/packages/funfix-exec/src/scheduler.js.flow
+++ b/packages/funfix-exec/src/scheduler.js.flow
@@ -17,6 +17,7 @@
 
 /* @flow */
 
+import type { Throwable } from "funfix-core"
 import { Duration } from "./time"
 import { Cancelable } from "./cancelable"
 import { DynamicRef } from "./ref"
@@ -31,7 +32,7 @@ declare export class Scheduler {
   executeAsync(runnable: () => void): void;
   trampoline(runnable: () => void): void;
 
-  reportFailure(e: any): void;
+  reportFailure(e: Throwable): void;
   currentTimeMillis(): number;
 
   scheduleOnce(delay: number | Duration, runnable: () => void): Cancelable;

--- a/packages/funfix-exec/src/scheduler.js.flow
+++ b/packages/funfix-exec/src/scheduler.js.flow
@@ -23,9 +23,9 @@ import { DynamicRef } from "./ref"
 
 declare export class Scheduler {
   /** @protected */
-  _batchIndex: number;
-  /** @protected */
   constructor(em: ExecutionModel): Scheduler;
+
+  batchIndex: number;
 
   executeBatched(runnable: () => void): void;
   executeAsync(runnable: () => void): void;

--- a/packages/funfix-exec/src/scheduler.js.flow
+++ b/packages/funfix-exec/src/scheduler.js.flow
@@ -55,7 +55,7 @@ declare export class TestScheduler extends Scheduler {
 }
 
 declare export class GlobalScheduler extends Scheduler {
-  constructor(canUseSetImmediate?: boolean, em?: ExecutionModel): GlobalScheduler;
+  constructor(canUseSetImmediate?: boolean, em?: ExecutionModel, reporter?: (e: Throwable) => void): GlobalScheduler;
 }
 
 declare export class ExecutionModel {

--- a/packages/funfix-exec/test/flow/cancelable.test.js.flow
+++ b/packages/funfix-exec/test/flow/cancelable.test.js.flow
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import {
+  StackedCancelable,
+  Cancelable,
+  ICancelable,
+  IBoolCancelable,
+  IAssignCancelable
+} from "../../src/"
+
+const ref1: StackedCancelable = StackedCancelable.empty()
+const ref2: StackedCancelable = new StackedCancelable()
+
+const ref3: StackedCancelable = new StackedCancelable([
+  Cancelable.of(() => console.info("Cancelled #1")),
+  Cancelable.of(() => console.info("Cancelled #2"))
+])
+
+const ref4: StackedCancelable = StackedCancelable.collection(
+  Cancelable.of(() => console.info("Cancelled #1")),
+  Cancelable.of(() => console.info("Cancelled #2"))
+)
+
+const ref5: StackedCancelable =
+  ref1.push(Cancelable.of(() => console.info("Cancelable #1")))
+
+const ref6: ICancelable = ref1.pop()
+
+const isCancelable: ICancelable = ref1
+const isBoolCancelable: IBoolCancelable = ref1
+
+// $ExpectError
+const isNotAssignCancelable: IAssignCancelable = ref1

--- a/packages/funfix-exec/test/flow/scheduler.test.js.flow
+++ b/packages/funfix-exec/test/flow/scheduler.test.js.flow
@@ -22,7 +22,8 @@ import {
   GlobalScheduler,
   TestScheduler,
   Duration,
-  ICancelable
+  ICancelable,
+  ExecutionModel
 } from "../../src/"
 
 const global: Scheduler = Scheduler.global.get()
@@ -61,3 +62,11 @@ Scheduler.global.bindL(() => new TestScheduler(), () => {
 })
 
 const idx: number = globalRef.batchIndex
+
+const globalRef2 = new GlobalScheduler(
+  false, 
+  ExecutionModel.alwaysAsync(), 
+  err => console.error(err))
+
+const global3 = globalRef2
+  .withExecutionModel(ExecutionModel.batched())

--- a/packages/funfix-exec/test/flow/scheduler.test.js.flow
+++ b/packages/funfix-exec/test/flow/scheduler.test.js.flow
@@ -59,3 +59,5 @@ Scheduler.global.bind(new TestScheduler(), () => {
 Scheduler.global.bindL(() => new TestScheduler(), () => {
   Scheduler.global.get()
 })
+
+const idx: number = globalRef.batchIndex

--- a/packages/funfix-exec/test/ts/scheduler.test.ts
+++ b/packages/funfix-exec/test/ts/scheduler.test.ts
@@ -90,23 +90,20 @@ describe("GlobalScheduler", () => {
 
   function testErrorReporting(f: (ec: Scheduler, r: () => void) => void): () => Promise<void> {
     return () => {
-      const oldFn = console.error
-      const ec = Scheduler.global.get()
       const dummy = new DummyError("dummy")
       let reported: any = null
 
       const p = new Promise<void>((resolve, _) => {
-        // Overriding console.error
-        console.error = (...args: any[]) => {
-          reported = args && args[0] || null
-          resolve(undefined)
-        }
+        const ec = new GlobalScheduler(true, ExecutionModel.global.get(),
+          (r: any) => {
+            reported = r
+            resolve(undefined)
+          })
 
         f(ec, () => { throw dummy })
       })
 
       return p.then(_ => {
-        console.error = oldFn
         assert.ok(reported, "reported != null")
         assert.equal(reported.message, "dummy")
       })
@@ -554,6 +551,23 @@ describe("TestScheduler", () => {
     const s5 = s.withExecutionModel(ExecutionModel.batched(200))
     assert.equal(s5.executionModel.type, "batched")
     assert.equal(s5.executionModel.recommendedBatchSize, 256)
+  })
+
+  it("withExecutionModel copies tasks left to execute", () => {
+    let effect = 0
+
+    const ec1 = new TestScheduler()
+    ec1.tick(1000)
+
+    ec1.executeAsync(() => { effect += 1 })
+    ec1.executeAsync(() => { effect += 2 })
+
+    const ec2 = ec1.withExecutionModel(ExecutionModel.alwaysAsync())
+    assert.equal(ec2.currentTimeMillis(), ec1.currentTimeMillis())
+    assert.equal(effect, 0)
+
+    ec2.tick()
+    assert.equal(effect, 3)
   })
 
   it("executes step by step with tickOne", () => {

--- a/packages/funfix-exec/test/ts/scheduler.test.ts
+++ b/packages/funfix-exec/test/ts/scheduler.test.ts
@@ -621,8 +621,10 @@ describe("TestScheduler", () => {
       ec.executeBatched(() => { count += 1 })
 
     assert.equal(count, batchSize - 1)
+    assert.equal(ec.batchIndex, 127)
     ec.tickOne()
     assert.equal(count, batchSize)
+    assert.equal(ec.batchIndex, 0)
     ec.tick()
     assert.equal(count, total)
   })

--- a/packages/funfix-types/src/instances.js.flow
+++ b/packages/funfix-types/src/instances.js.flow
@@ -20,7 +20,7 @@
 import type { Throwable } from "funfix-core"
 import { Option, Try, Either } from "funfix-core"
 import { Future } from "funfix-exec"
-import { Eval } from "funfix-effect"
+import { Eval, IO } from "funfix-effect"
 import { HK } from "./kinds"
 
 export type OptionK<A> = HK<Option<any>, A>;
@@ -131,4 +131,27 @@ declare export class FutureInstances {
   forEffectL: <A, B>(fa: FutureK<A>, fb: () => FutureK<B>) => Future<A>;
 
   static global: FutureInstances;
+}
+
+export type IOK<A> = HK<IO<any>, A>;
+
+declare export class IOInstances {
+  pure<A>(a: A): IO<A>;
+  flatMap<A, B>(fa: IOK<A>, f: (a: A) => IOK<B>): IO<B>;
+  tailRecM<A, B>(a: A, f: (a: A) => IOK<Either<A, B>>): IO<B>;
+  ap<A, B>(fa: IOK<A>, ff: IOK<(a: A) => B>): IO<B>;
+  map<A, B>(fa: IOK<A>, f: (a: A) => B): IO<B>;
+  unit(): IO<void>;
+  raise<A>(e: Throwable): IO<A>;
+  attempt<A>(fa: IOK<A>): IO<Either<Throwable, A>>;
+  recoverWith<A>(fa: IOK<A>, f: (e: Throwable) => IOK<A>): IO<A>;
+  recover<A>(fa: IOK<A>, f: (e: Throwable) => A): IO<A>;
+  map2: <A, B, Z>(fa: IOK<A>, fb: IOK<B>, f: (a: A, b: B) => Z) => IO<Z>;
+  product: <A, B>(fa: IOK<A>, fb: IOK<B>) => IOK<[A, B]>;
+  followedBy: <A, B>(fa: IOK<A>, fb: IOK<B>) => IO<B>;
+  followedByL: <A, B>(fa: IOK<A>, fb: () => IOK<B>) => IO<B>;
+  forEffect: <A, B>(fa: IOK<A>, fb: IOK<B>) => IO<A>;
+  forEffectL: <A, B>(fa: IOK<A>, fb: () => IOK<B>) => IO<A>;
+
+  static global: IOInstances;
 }

--- a/packages/funfix-types/test/flow/io.test.js.flow
+++ b/packages/funfix-types/test/flow/io.test.js.flow
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 by The Funfix Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import type { Throwable } from "funfix-core"
+import { IO } from "funfix-effect"
+import {
+  MonadError,
+  monadErrorOf,
+  Monad,
+  monadOf,
+  FlatMap,
+  flatMapOf,
+  ApplicativeError,
+  applicativeErrorOf,
+  Applicative,
+  applicativeOf,
+  Apply,
+  applyOf,
+  Functor,
+  functorOf,
+  IOInstances
+} from "../../src/"
+
+const functor1: Functor<IO<any>> = functorOf(IO)
+const functor2: Functor<IO<any>> = IOInstances.global
+
+const ap1: Apply<IO<any>> = applyOf(IO)
+const ap2: Apply<IO<any>> = IOInstances.global
+
+const applicative1: Applicative<IO<any>> = applicativeOf(IO)
+const applicative2: Applicative<IO<any>> = IOInstances.global
+
+const flatMap1: FlatMap<IO<any>> = flatMapOf(IO)
+const flatMap2: FlatMap<IO<any>> = IOInstances.global
+
+const apErr1: ApplicativeError<IO<any>, any> = applicativeErrorOf(IO)
+const apErr2: ApplicativeError<IO<any>, Throwable> = IOInstances.global
+
+const monad1: Monad<IO<any>> = monadOf(IO)
+const monad2: Monad<IO<any>> = IOInstances.global
+
+const monadErr1: MonadError<IO<any>, any> = monadErrorOf(IO)
+const monadErr2: MonadError<IO<any>, Throwable> = IOInstances.global

--- a/packages/funfix-types/test/ts/io.test.ts
+++ b/packages/funfix-types/test/ts/io.test.ts
@@ -15,19 +15,22 @@
  * limitations under the License.
  */
 
-import { Future, Scheduler, TestScheduler, ExecutionModel } from "funfix-exec"
+import {  Scheduler, TestScheduler, ExecutionModel } from "funfix-exec"
+import { IO } from "funfix-effect"
 import * as jv from "jsverify"
 import * as laws from "./laws"
 import * as inst from "./instances"
 import { Eq } from "../../src/"
 
-describe("Future obeys type class laws", () => {
+describe("IO obeys type class laws", () => {
   const ec = new TestScheduler(ex => { throw ex }, ExecutionModel.synchronous())
   const eq = new (
-    class extends Eq<Future<any>> {
-      eqv(lh: Future<any>, rh: Future<any>): boolean {
+    class extends Eq<IO<any>> {
+      eqv(lh: IO<any>, rh: IO<any>): boolean {
+        const f1 = lh.run(ec)
+        const f2 = rh.run(ec)
         ec.tick(1000 * 60 * 60 * 24 * 10)
-        return !lh.value().isEmpty() && lh.value().equals(rh.value())
+        return !f1.value().isEmpty() && f1.value().equals(f2.value())
       }
     })()
 
@@ -39,6 +42,5 @@ describe("Future obeys type class laws", () => {
     Scheduler.global.revert()
   })
 
-  const arbF = inst.arbFuture(ec)
-  laws.testMonadError(Future, jv.number, arbF, jv.string, eq)
+  laws.testMonadError(IO, jv.number, inst.arbIO, jv.string, eq)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,7 +3276,7 @@ typescript@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
-typescript@~2.5.1:
+typescript@rc:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
 


### PR DESCRIPTION
Summary:

1. lawful
2. lazy
3. **cancelable**
4. async
5. optionally memoizable
6. among the fastest implementations available, while addressing [fairness concerns](https://github.com/funfix/funfix/pull/37)
7. inspired by [Monix's Task](https://monix.io/docs/2x/eval/task.html) and by [cats.effect.IO](https://github.com/typelevel/cats-effect)
8. probably the best Promise alternative from JavaScript's ecosystem 😎

Work still in progress!

NOTE: for review, the important part is [io.ts](https://github.com/funfix/funfix/pull/38/files#diff-0d4c4a74b56c922ec541e3188ae5f1ec).

## Intro

Compared with Funfix's [Future](https://funfix.org/api/exec/classes/future.html) (from the [funfix-exec](https://funfix.org/api/exec/) sub-project) or JavaScript's [Promise](https://promisesaplus.com), IO does not represent a running computation or a value detached from time, as `IO` does not execute anything when working with its builders or operators and it does not submit any work into the Scheduler or any run-loop for execution, the execution eventually taking place only after IO.run is called and not before that.

In order to understand `IO`, here's the design space:

 |                  | Strict                    | Lazy                          |
 |------------------|:-------------------------:|:-----------------------------:|
 | **Synchronous**  | `A`                       | `() => A`                     |
 |                  |                           | `Eval<A>`               |
 | **Asynchronous** | `(Try<A> => void) => void`          | `() => ((Try<A> => void) => void)`      |
 |                  | `Future<A>` / `Promise`   | `IO<A>`                 |

JavaScript is a language (and runtime) that's strict by default,meaning that expressions are evaluated immediately instead of being evaluated on a by-need basis, like in Haskell.

So a value `A` is said to be strict. To turn an `A` value into a lazy value, you turn that expression into a parameterless function of type `() => A`, also called a "thunk".

A [Future](https://funfix.org/api/exec/classes/future.html) is a value that's produced by an asynchronous process, but it is said to have strict behavior, meaning that when you receive a `Future`reference, whatever process that's supposed to complete the `Future` has probably started already. This goes for [JavaScript's Promise](https://promisesaplus.com) as well.

But there are cases where we don't want strict values, but lazily evaluated ones. In some cases we want functions, or `Future`-generators. Because we might want better handling of parallelism, or we might want to suspend *side effects*. As without suspending *side effects* we don't have *referential transparency*, which really helps with reasoning about the code, being the essence of *functional programming*.

This `IO` type is thus the complement to `Future`, a lazy, lawful monadic type that can describe any side effectful action, including asynchronous ones, also capable of suspending side effects.

## Usage Sample (from included JSDoc)

To build an `IO` from a parameterless function returning a value (a thunk), we can use `IO.of`:

```typescript
const hello = IO.of(() => "Hello ")
const world = IO.of(() => "World!")
  ```
 
Nothing gets executed yet, as `IO` is lazy, nothing executes until you trigger `IO.run` on it.
 
To combine `IO` values we can use `map` and `flatMap`, which describe sequencing and this time is in a very real sense because of the laziness involved:
 
```typescript
const sayHello = hello
  .flatMap(h => world.map(w => h + w))
  .map(console.info)
  ```
 
This `IO` reference will trigger a side effect on evaluation, but not yet. To make the above print its message:
 
```typescript
const f: Future<void> = sayHello.run()
//=> Hello World!
```
 
The returned type is a [Future](https://funfix.org/api/exec/classes/future.html), a value that can be completed already or might be completed at some point in the future, once the running asynchronous process finishes.
 
Futures can also be canceled, in case the described computation can be canceled. Not in this case (since there's nothing that can be cancelled when building tasks with `IO.of`), but we can build cancelable tasks with `IO.async`:
 
```typescript
import { Cancelable, Success, IO } from "funfix"
 
const delayedHello = IO.async((scheduler, callback) => {
  const task = scheduler.scheduleOnce(1000, () => {
    console.info("Delayed Hello!")
    // Signaling successful completion
    // ("undefined" inhabits type "void")
    callback(Success(undefined))
  })
 
  return Cancelable.of(() => {
    console.info("Cancelling!")
    task.cancel()
  })
})
```
 
The sample above prints a message with a delay, where the delay itself is scheduled with the injected `Scheduler`. The `Scheduler`is in fact an optional parameter to `IO.run` and if one isn't explicitly provided, then `Scheduler.global` is assumed.
 
This action can be cancelled, because it specifies cancellation logic. If we wouldn't return an explicit `Cancelable` there,then cancellation wouldn't work. But for this `IO` reference it does:
 
```typescript
// Triggering execution, which sends a task to execute by means
// of JavaScript's setTimeout (under the hood):
const f: Future<void> = delayedHello.run()
 
// If we change our mind before the timespan has passed:
f.cancel()
//=> Cancelling!
```

Note that if the cancellation actually happens (so before the timespan has passed), then this `Future` will no longer complete with any result. Cancellation, when specified, interrupts the connection between the producer and the consumer, being an action that's *concurrent* with the process that is producing the result (which is why we cannot do automatic cancelation by default, because resource handling might be needed).