### PR TITLE
feat(effect): Eval is no longer a MonadError

### DIFF
--- a/packages/funfix-effect/src/eval.js.flow
+++ b/packages/funfix-effect/src/eval.js.flow
@@ -17,47 +17,29 @@
 
 /* @flow */
 
-import type { Throwable } from "funfix-core"
-import { Try, Either } from "funfix-core"
+import { Either } from "funfix-core"
 
 declare export class Eval<+A> {
   get(): A;
-  run(): Try<A>;
-
-  getOrElse<AA>(fallback: AA): A | AA;
-  getOrElseL<AA>(thunk: () => AA): A | AA;
 
   map<B>(f: (a: A) => B): Eval<B>;
   flatMap<B>(f: (a: A) => Eval<B>): Eval<B>;
   chain<B>(f: (a: A) => Eval<B>): Eval<B>;
-  transform<R>(failure: (e: Throwable) => R, success: (a: A) => R): Eval<R>;
-  transformWith<R>(failure: (e: Throwable) => Eval<R>, success: (a: A) => Eval<R>): Eval<R>;
-
-  recover<AA>(f: (e: Throwable) => AA): Eval<A | AA>;
-  recoverWith<AA>(f: (e: Throwable) => Eval<AA>): Eval<A | AA>;
-  attempt(): Eval<Either<Throwable, A>>;
-
   memoize(): Eval<A>;
-  memoizeOnSuccess(): Eval<A>;
   forEachL(cb: (a: A) => void): Eval<void>;
   forEach(cb: (a: A) => void): void;
 
-  // Implements HK<F, A>
   +_funKindF: Eval<any>;
   +_funKindA: A;
-
-  // Implements Constructor<T>
   static +_funErasure: Eval<any>;
 
   static of<A>(thunk: () => A): Eval<A>;
   static pure<A>(value: A): Eval<A>;
   static now<A>(value: A): Eval<A>;
   static unit(): Eval<void>;
-  static raise(e: Throwable): Eval<empty>;
   static always<A>(thunk: () => A): Eval<A>;
   static once<A>(thunk: () => A): Eval<A>;
   static suspend<A>(thunk: () => Eval<A>): Eval<A>;
   static defer<A>(thunk: () => Eval<A>): Eval<A>;
-
   static tailRecM<A, B>(a: A, f: (a: A) => Eval<Either<A, B>>): Eval<B>;
 }

--- a/packages/funfix-effect/src/io.ts
+++ b/packages/funfix-effect/src/io.ts
@@ -200,6 +200,35 @@ import {
  * io.executeWithModel(ExecutionModel.batched(256))
  * ```
  *
+ * ## Versus IO
+ *
+ * For dealing with lazy evaluation, the other alternative is
+ * the {@link Eval} data type.
+ *
+ * Differences between `Eval` and `IO`:
+ *
+ * 1. `IO` is capable of describing asynchronous computations as well
+ * 2. `IO` is capable of error handling (it implements `MonadError`),
+ *    whereas `Eval` does not provide error handling capabilities,
+ *    being meant to be used for pure expressions (it implements
+ *    `Comonad`, which is incompatible with `MonadError`)
+ * 3. You cannot rely on `IO` to produce a value immediately, since
+ *    we cannot block threads on top of JavaScript engines
+ *
+ * So if you need error handling capabilities
+ * (i.e. `MonadError<Throwable, ?>`), or if you need to describe
+ * asynchronous processes, then `IO` is for you. {@link Eval}
+ * is a simpler data type with the sole purpose of controlling the
+ * evaluation of expressions (i.e. strict versus lazy).
+ *
+ * ## Credits
+ *
+ * This type is inspired by `cats.effect.IO` from
+ * {@link http://typelevel.org/cats/|Typelevel Cats},
+ * by `monix.eval.Task` from {@link https://monix.io|Monix}, by
+ * `scalaz.effect.IO` from [Scalaz](https://github.com/scalaz/scalaz),
+ * which are all inspired by Haskell's `IO` data type.
+ *
  * @final
  */
 export class IO<A> {

--- a/packages/funfix-effect/test/flow/eval.test.js.flow
+++ b/packages/funfix-effect/test/flow/eval.test.js.flow
@@ -17,8 +17,8 @@
 
 /* @flow */
 
+import { Right } from "funfix-core"
 import * as ff from "../../src/"
-import { Try, Right, Either } from "funfix-core"
 import { Eval } from "../../src/"
 
 const ref1: ff.Eval<number> = ff.Eval.always(() => 1)
@@ -37,46 +37,11 @@ const animal: Eval<Animal> = Eval.always(() => new Dog())
 const error2: Eval<Dog> = Eval.always(() => new Animal())
 
 const r1: number = ref1.get()
-const tr1: Try<number> = ref1.run()
-const r2: number = ref1.getOrElse(0)
-const r3: number = ref1.getOrElseL(() => 0)
 
 // Covariance for getOrElse and getOrElseL
 const dogEval: Eval<Dog> = Eval.always(() => new Dog())
-const r4: Animal = dogEval.getOrElse(new Animal())
-const r5: Animal = dogEval.getOrElseL(() => new Animal())
-const r6: Animal = dogEval.getOrElse(new Cat())
-const r7: Object = dogEval.getOrElse(new Human())
-
-// $ExpectError
-const super11: Dog = dogEval.getOrElse(new Cat())
-// $ExpectError
-const super21: Dog = dogEval.getOrElseL(() => new Cat())
-// $ExpectError
-const super12: Animal = dogEval.getOrElse(new Human())
-// $ExpectError
-const super22: Animal = dogEval.getOrElseL(() => new Human())
-// $ExpectError
-const super13: Human = dogEval.getOrElse(new Human())
-// $ExpectError
-const super23: Human = dogEval.getOrElseL(() => new Human())
-
-// Covariance for recover and recoverWith
-const recover1: Eval<Animal> = dogEval.recover(_ => new Animal())
-const recover2: Eval<Animal> = dogEval.recoverWith(_ => Eval.now(new Animal()))
-const recover3: Eval<Animal> = dogEval.recover(_ => new Cat())
-const recover4: Eval<Animal> = dogEval.recoverWith(_ => Eval.now(new Cat()))
-const recover5: Eval<Object> = dogEval.recover(_ => new Human())
-const recover6: Eval<Object> = dogEval.recoverWith(_ => Eval.now(new Human()))
-
-// $ExpectError
-const recoverE1: Eval<string> = dogEval.recoverWith(_ => Eval.now(new Human()))
-// $ExpectError
-const recoverE2: Eval<Dog> = dogEval.recover(_ => new Animal())
-
-const a1: Eval<Either<any, Dog>> = dogEval.attempt()
-// $ExpectError
-const a2: Eval<Either<any, Cat>> = dogEval.attempt()
+const cov1: Eval<Animal> = dogEval
+const cov2: Eval<Object> = dogEval
 
 // Map and flatMap
 const r14: Eval<Cat> = dogEval.map(_ => new Cat())
@@ -85,22 +50,10 @@ const r16: Eval<Cat> = dogEval.chain(_ => Eval.now(new Cat()))
 // $ExpectError
 const error5: Eval<Cat> = dogEval.flatMap(_ => new Cat())
 
-// Transform and TransformWith
-const r17: Eval<Cat> = dogEval.transform(
-  (error: any) => new Cat(),
-  (_: Dog) => new Cat()
-)
-const r18: Eval<Cat> = dogEval.transformWith(
-  (error: any) => Eval.now(new Cat()),
-  (_: Dog) => Eval.now(new Cat())
-)
-
 // Builders
 const r19: Eval<Cat> = Eval.of(() => new Cat())
 const r20: Eval<Cat> = Eval.always(() => new Cat())
 const r21: Eval<Cat> = Eval.once(() => new Cat())
-const r22: Eval<Cat> = Eval.raise("error")
-const r23: Eval<empty> = Eval.raise("error")
 const r24: Eval<Cat> = Eval.now(new Cat())
 const r25: Eval<Cat> = Eval.pure(new Cat())
 const r26: Eval<Cat> = Eval.suspend(() => Eval.now(new Cat()))
@@ -120,7 +73,6 @@ const error11: Eval<Dog> = Eval.suspend(() => Eval.now(new Cat()))
 
 // Memoize
 const r27: Eval<Cat> = Eval.of(() => new Cat()).memoize()
-const r28: Eval<Cat> = Eval.of(() => new Cat()).memoizeOnSuccess()
 
 const u: Eval<void> = Eval.unit()
 const a: Eval<number> = Eval.tailRecM("initial", a => Eval.now(Right(1)))

--- a/packages/funfix-effect/test/ts/eval.test.ts
+++ b/packages/funfix-effect/test/ts/eval.test.ts
@@ -17,13 +17,8 @@
 
 import {
   is, id,
-  Try,
-  Success,
-  Failure,
   Left,
-  Right,
-  DummyError,
-  IllegalStateError
+  Right, DummyError
 } from "funfix-core"
 
 import * as jv from "jsverify"
@@ -32,15 +27,8 @@ import * as assert from "./asserts"
 import { Eval } from "../../src/"
 
 describe("Eval basic data constructors tests", () => {
-  it("sealed class",() => {
-    class Another extends Eval<number> {}
-    const err = Try.of(() => new Another().get()).failed().get()
-    assert.ok(err instanceof IllegalStateError, "err instanceof IllegalStateError")
-  })
-
   it("now(a) should yield value", () => {
     assert.equal(Eval.now("value").get(), "value")
-    assert.ok(is(Eval.now("value").run(), Success("value")))
   })
 
   it("now(a).flatMap(f) works", () => {
@@ -48,52 +36,8 @@ describe("Eval basic data constructors tests", () => {
     assert.equal(fa.get(), 2)
   })
 
-  it("now(a).transform(f) works", () => {
-    const fa = Eval.now(1).transform(_ => { throw _ }, a => a + 1)
-    assert.equal(fa.get(), 2)
-  })
-
-  it("now(a).transformWith(f) works", () => {
-    const fa = Eval.now(1).transformWith(
-      err => Eval.raise(err),
-      a => Eval.now(a + 1)
-    )
-    assert.equal(fa.get(), 2)
-  })
-
   it("String(now(a))", () => {
     assert.equal(String(Eval.now("value")), 'Eval.now("value")')
-  })
-
-  it("raise(err) should trigger failure", () => {
-    assert.throws(() => Eval.raise("error").get())
-    assert.ok(is(Eval.raise("error").run(), Failure("error")))
-  })
-
-  it("raise(err).flatMap(f) works", () => {
-    const fe: Eval<number> = Eval.raise("error")
-    const fa = fe.flatMap(a => Eval.now(a + 1))
-    assert.ok(is(fa.run(), Failure("error")))
-  })
-
-  it("raise(err).transform(f) works", () => {
-    const fa = (Eval.raise("error") as Eval<number>).transform(
-      _ => 100,
-      a => a + 1
-    )
-    assert.equal(fa.get(), 100)
-  })
-
-  it("raise(err).transformWith(f) works", () => {
-    const fa = (Eval.raise("error") as Eval<number>).transformWith(
-      _ => Eval.always(() => 100),
-      a => Eval.now(a + 1)
-    )
-    assert.equal(fa.get(), 100)
-  })
-
-  it("String(raise(error))", () => {
-    assert.equal(String(Eval.raise("error")), 'Eval.raise("error")')
   })
 
   it("once() should do memoization", () => {
@@ -106,20 +50,23 @@ describe("Eval basic data constructors tests", () => {
 
     const fn2 = Eval.once(() => { effect += 1; return effect })
 
-    assert.ok(is(fn2.run(), Success(2)))
-    assert.ok(is(fn2.run(), Success(2)))
+    assert.equal(fn2.get(), 2)
+    assert.equal(fn2.get(), 2)
+  })
+
+  it("once() should memoize errors too", () => {
+    let effect = 0
+    const dummy = new DummyError()
+    const fn1 = Eval.once(() => { effect += 1; throw effect })
+
+    assert.throws(() => fn1.get())
+    assert.equal(effect, 1)
+    assert.throws(() => fn1.get())
+    assert.equal(effect, 1)
   })
 
   it("once(a).flatMap(f) works", () => {
     const fa = Eval.once(() => 1).flatMap(a => Eval.once(() => a + 1))
-    assert.equal(fa.get(), 2)
-  })
-
-  it("once(a).transformWith(f,g) works", () => {
-    const fa = Eval.once(() => 1).transformWith(
-      err => Eval.raise(err),
-      a => Eval.once(() => a + 1)
-    )
     assert.equal(fa.get(), 2)
   })
 
@@ -134,20 +81,12 @@ describe("Eval basic data constructors tests", () => {
 
     assert.equal(fn.get(), 1)
     assert.equal(fn.get(), 2)
-    assert.ok(is(fn.run(), Success(3)))
-    assert.ok(is(fn.run(), Success(4)))
+    assert.equal(fn.get(), 3)
+    assert.equal(fn.get(), 4)
   })
 
   it("always(a).flatMap(f) works", () => {
     const fa = Eval.always(() => 1).flatMap(a => Eval.always(() => a + 1))
-    assert.equal(fa.get(), 2)
-  })
-
-  it("always(a).transformWith(f,g) works", () => {
-    const fa = Eval.always(() => 1).transformWith(
-      err => Eval.raise(err),
-      a => Eval.always(() => a + 1)
-    )
     assert.equal(fa.get(), 2)
   })
 
@@ -163,8 +102,8 @@ describe("Eval basic data constructors tests", () => {
     assert.equal(effect, 0)
     assert.equal(fn.get(), 1)
     assert.equal(fn.get(), 2)
-    assert.ok(is(fn.run(), Success(3)))
-    assert.ok(is(fn.run(), Success(4)))
+    assert.equal(fn.get(), 3)
+    assert.equal(fn.get(), 4)
   })
 
   it("suspend(fa).flatMap(f) works", () => {
@@ -173,19 +112,11 @@ describe("Eval basic data constructors tests", () => {
     assert.equal(fa.get(), 2)
   })
 
-  it("suspend(fa).transformWith(f,g) works", () => {
-    const fa = Eval.suspend(() => Eval.always(() => 1)).transformWith(
-      Eval.raise,
-      a => Eval.always(() => a + 1)
-    )
-    assert.equal(fa.get(), 2)
-  })
-
   jv.property("defer is an alias for suspend",
     jv.number, jv.fn(inst.arbEval),
     (n, f) => {
       const thunk = () => f(n)
-      return is(Eval.defer(thunk).run(), Eval.suspend(thunk).run())
+      return is(Eval.defer(thunk).get(), Eval.suspend(thunk).get())
     }
   )
 
@@ -210,139 +141,6 @@ describe("Eval basic data constructors tests", () => {
   })
 })
 
-describe("Eval error handling", () => {
-  it("attempt for success", () => {
-    assert.equal(Eval.pure(10).attempt().get(), Right(10))
-  })
-
-  it("attempt for failure", () => {
-    const dummy = new DummyError("error")
-    assert.equal(Eval.raise(dummy).attempt().get(), Left(dummy))
-  })
-
-  it("flatMap() protects against user error", () => {
-    const dummy = new DummyError("dummy")
-    const r = Eval.now(1).flatMap(a => { throw dummy }).run()
-    assert.ok(is(r, Failure(dummy)))
-  })
-
-  it("flatMap() error can recover, test #1", () => {
-    const dummy = new DummyError("dummy")
-    const r = Eval.now(1)
-      .flatMap<number>(a => { throw dummy })
-      .recover(e => { if (e === dummy) return 100; else throw e })
-      .flatMap(a => Eval.now(a + 1))
-      .run()
-
-    assert.equal(r.get(), 101)
-  })
-
-  it("flatMap() error can recover, test #2", () => {
-    const dummy = new DummyError("dummy")
-    const r = Eval.now(1)
-      .flatMap<number>(a => { throw dummy })
-      .flatMap(a => Eval.now(a + 1))
-      .recover(e => { if (e === dummy) return 100; else throw e })
-      .flatMap(a => Eval.now(a + 1))
-      .run()
-
-    assert.equal(r.get(), 101)
-  })
-
-  it("always() protects against user code", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.always<number>(() => { throw dummy })
-    assert.ok(is(fa.run(), Failure(dummy)))
-  })
-
-  it("always() can recover", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.always<number>(() => { throw dummy }).recover(_ => 100)
-    assert.ok(is(fa.run(), Success(100)))
-  })
-
-  it("once() protects against user code", () => {
-    let effect = 0
-    const dummy = new DummyError("dummy")
-    const fa = Eval.once<number>(() => { effect += 1; throw dummy })
-
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-  })
-
-  it("once() can recover", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.once<number>(() => { throw dummy }).recover(_ => 100)
-    assert.ok(is(fa.run(), Success(100)))
-  })
-
-  it("suspend() protects against user code", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.suspend<number>(() => { throw dummy })
-    assert.ok(is(fa.run(), Failure(dummy)))
-  })
-
-  it("suspend() can recover", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.suspend<number>(() => { throw dummy }).recover(_ => 100)
-    assert.ok(is(fa.run(), Success(100)))
-  })
-
-  it("transform protects against user code on success", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.now(100).transform<number>(e => { throw e }, _ => { throw dummy })
-    assert.ok(is(fa.run(), Failure(dummy)))
-  })
-
-  it("transform protects against user code on failure", () => {
-    const dummy1 = new DummyError("dummy1")
-    const dummy2 = new DummyError("dummy2")
-
-    const fa = Eval.raise(dummy1).transformWith<number>(_ => { throw dummy2 }, id)
-    assert.ok(is(fa.run(), Failure(dummy2)))
-  })
-
-  it("transformWith protects against user code on success", () => {
-    const dummy = new DummyError("dummy")
-    const fa = Eval.now(100).transformWith<number>(Eval.raise, _ => { throw dummy })
-    assert.ok(is(fa.run(), Failure(dummy)))
-  })
-
-  it("transformWith protects against user code on failure", () => {
-    const dummy1 = new DummyError("dummy1")
-    const dummy2 = new DummyError("dummy2")
-
-    const fa = Eval.raise(dummy1).transformWith<number>(_ => { throw dummy2 }, Eval.now)
-    assert.ok(is(fa.run(), Failure(dummy2)))
-  })
-
-  jv.property("getOrElse() mirrors the source on success",
-    inst.arbEval,
-    fa => {
-      const ref = fa.recover(_ => 0)
-      return is(ref.getOrElse(10000), ref.get())
-    })
-
-  it("getOrElse() returns the fallback on failure", () => {
-    const fa: Eval<number> = Eval.raise("error")
-    assert.equal(fa.getOrElse(100), 100)
-  })
-
-  jv.property("getOrElseL() mirrors the source on success",
-    inst.arbEval,
-    fa => {
-      const ref = fa.recover(_ => 0)
-      return is(ref.getOrElseL(() => 10000), ref.get())
-    })
-
-  it("getOrElseL() returns the fallback on failure", () => {
-    const fa: Eval<number> = Eval.raise("error")
-    assert.equal(fa.getOrElseL(() => 100), 100)
-  })
-})
-
 describe("Eval is a monad", () => {
   jv.property("success(n).flatMap(f) <-> f(n) (left identity)",
     jv.number, jv.fn(inst.arbEval),
@@ -351,17 +149,12 @@ describe("Eval is a monad", () => {
 
   jv.property("right identity",
     inst.arbEval,
-    fa => is(fa.flatMap(Eval.pure).run(), fa.run())
-  )
-
-  jv.property("failure.flatMap(f) == failure",
-    jv.fn(inst.arbEval),
-    f => is(Eval.raise("error").flatMap(f).run(), Failure("error"))
+    fa => is(fa.flatMap(Eval.pure).get(), fa.get())
   )
 
   jv.property("chain is an alias of flatMap",
     inst.arbEval, jv.fn(inst.arbEval),
-    (fa, f) => is(fa.flatMap(f).run(), fa.chain(f).run())
+    (fa, f) => is(fa.flatMap(f).get(), fa.chain(f).get())
   )
 
   it("flatMap is tail safe", () => {
@@ -376,17 +169,17 @@ describe("Eval is a monad", () => {
 
   jv.property("pure(n).map(f) === pure(f(n))",
     jv.number, jv.fn(jv.number),
-    (n, f) => is(Eval.pure(n).map(f).run(), Eval.pure(f(n)).run())
+    (n, f) => is(Eval.pure(n).map(f).get(), Eval.pure(f(n)).get())
   )
 
   jv.property("covariant identity",
     inst.arbEval,
-    fa => is(fa.map(id).run(), fa.run())
+    fa => is(fa.map(id).get(), fa.get())
   )
 
   jv.property("covariant composition",
     inst.arbEval, jv.fn(jv.number), jv.fn(jv.number),
-    (fa, f, g) => is(fa.map(f).map(g).run(), fa.map(x => g(f(x))).run())
+    (fa, f, g) => is(fa.map(f).map(g).get(), fa.map(x => g(f(x))).get())
   )
 
   it("map is tail safe", () => {
@@ -401,19 +194,14 @@ describe("Eval is a monad", () => {
     const e2 = Eval.unit()
 
     assert.equal(e1, e2)
-    assert.equal(e1.run().get(), undefined)
+    assert.equal(e1.get(), undefined)
   })
 })
 
 describe("Eval memoization", () => {
   jv.property("memoize mirrors the source for pure functions",
     inst.arbEval,
-    fa => is(fa.memoize().run(), fa.run())
-  )
-
-  jv.property("memoizeOnSuccess mirrors the source for pure functions",
-    inst.arbEval,
-    fa => is(fa.memoizeOnSuccess().run(), fa.run())
+    fa => is(fa.memoize().get(), fa.get())
   )
 
   it("now, raise and once returns the same reference on .memoize", () => {
@@ -431,18 +219,6 @@ describe("Eval memoization", () => {
     assert.equal(fa.get(), 1)
   })
 
-  it("always().memoize caches failures", () => {
-    const dummy = new DummyError("dummy")
-    let effect = 0
-    const source = Eval.always(() => { effect += 1; throw dummy })
-    const fa = source.memoize()
-
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-  })
-
   it("any.flatMap.memoize caches successful results", () => {
     let effect = 0
     const source = Eval.now(1).map(x => { effect += x; return effect })
@@ -452,89 +228,17 @@ describe("Eval memoization", () => {
     assert.equal(fa.get(), 1)
     assert.equal(fa.get(), 1)
   })
-
-  it("any.flatMap.memoize caches failures", () => {
-    const dummy = new DummyError("dummy")
-    let effect = 0
-    const source = Eval.now(1).flatMap(x => { effect += x; throw dummy })
-    const fa = source.memoize()
-
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-  })
-
-  // ---
-  it("now, raise and once returns the same reference on .memoizeOnSuccess", () => {
-    const fa1 = Eval.now(1)
-    assert.equal(fa1.memoizeOnSuccess(), fa1)
-  })
-
-  it("always().memoizeOnSuccess caches successful results", () => {
-    let effect = 0
-    const source = Eval.always(() => { effect += 1; return effect })
-    const fa = source.memoizeOnSuccess()
-
-    assert.equal(fa.get(), 1)
-    assert.equal(fa.get(), 1)
-    assert.equal(fa.get(), 1)
-  })
-
-  it("always().memoizeOnSuccess does not cache failures", () => {
-    const dummy = new DummyError("dummy")
-    let effect = 0
-    const source = Eval.always(() => { effect += 1; throw dummy })
-    const fa = source.memoizeOnSuccess()
-
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 2)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 3)
-  })
-
-  it("any.flatMap.memoizeOnSuccess caches successful results", () => {
-    let effect = 0
-    const source = Eval.now(1).map(x => { effect += x; return effect })
-    const fa = source.memoizeOnSuccess()
-
-    assert.equal(fa.get(), 1)
-    assert.equal(fa.get(), 1)
-    assert.equal(fa.get(), 1)
-  })
-
-  it("any.flatMap.memoizeOnSuccess caches failures", () => {
-    const dummy = new DummyError("dummy")
-    let effect = 0
-    const source = Eval.now(1).flatMap(x => { effect += x; throw dummy })
-    const fa = source.memoizeOnSuccess()
-
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 1)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 2)
-    assert.ok(is(fa.run(), Failure(dummy)))
-    assert.equal(effect, 3)
-  })
 })
 
 describe("Eval.foreach and foreachL", () => {
   jv.property("forEach works for successful results",
     inst.arbEval,
-    arbEval => {
+    fa => {
       let effect = 0
-      const fa = arbEval.recover(_ => 0)
       fa.forEach(a => { effect = a })
       return effect === fa.get()
     }
   )
-
-  it("forEach throws exception for failures", () => {
-    const fa: Eval<number> = Eval.raise("dummy")
-    assert.throws(() => fa.forEach(a => {}))
-  })
 })
 
 describe("Eval.tailRecM", () => {
@@ -542,16 +246,4 @@ describe("Eval.tailRecM", () => {
     const fa = Eval.tailRecM(0, a => Eval.now(a < 1000 ? Left(a + 1) : Right(a)))
     assert.equal(fa.get(), 1000)
   })
-
-  it("returns the failure unchanged", () => {
-    const fa = Eval.tailRecM(0, a => Eval.raise("failure"))
-    assert.equal(fa.run().failed().get(), "failure")
-  })
-
-  it("protects against user errors", () => {
-    // tslint:disable:no-string-throw
-    const fa = Eval.tailRecM(0, a => { throw "dummy" })
-    assert.equal(fa.run().failed().get(), "dummy")
-  })
 })
-

--- a/packages/funfix-effect/test/ts/instances.ts
+++ b/packages/funfix-effect/test/ts/instances.ts
@@ -17,21 +17,19 @@
 
 import * as jv from "jsverify"
 import { Eval, IO } from "../../src/"
-import {Failure, Success} from "funfix-core";
+import { Failure, Success } from "funfix-core"
 
 export const arbEval: jv.Arbitrary<Eval<number>> =
   jv.pair(jv.number, jv.number).smap(
     v => {
-      switch (v[0] % 6) {
+      switch (v[0] % 5) {
         case 0:
           return Eval.now(v[1])
         case 1:
-          return Eval.raise(v[1])
-        case 2:
           return Eval.always(() => v[1])
-        case 3:
+        case 2:
           return Eval.once(() => v[1])
-        case 4:
+        case 3:
           return Eval.suspend(() => Eval.now(v[1]))
         default:
           return Eval.now(0).flatMap(_ => Eval.now(v[1]))

--- a/packages/funfix-types/src/instances.js.flow
+++ b/packages/funfix-types/src/instances.js.flow
@@ -102,10 +102,6 @@ declare export class EvalInstances {
   followedByL<A, B>(fa: EvalK<A>, fb: () => EvalK<B>): Eval<B>;
   forEffect<A, B>(fa: EvalK<A>, fb: EvalK<B>): Eval<A>;
   forEffectL<A, B>(fa: EvalK<A>, fb: () => EvalK<B>): Eval<A>;
-  raise<A>(e: Throwable): Eval<A>;
-  attempt<A>(fa: EvalK<A>): Eval<Either<Throwable, A>>;
-  recoverWith<A>(fa: EvalK<A>, f: (e: Throwable) => EvalK<A>): Eval<A>;
-  recover<A>(fa: EvalK<A>, f: (e: Throwable) => A): Eval<A>;
 
   static global: EvalInstances;
 }

--- a/packages/funfix-types/src/instances.ts
+++ b/packages/funfix-types/src/instances.ts
@@ -249,7 +249,7 @@ export type EvalK<A> = HK<Eval<any>, A>
 /**
  * Type class instances provided by default for `Eval`.
  */
-export class EvalInstances implements MonadError<Eval<any>, Throwable> {
+export class EvalInstances implements Monad<Eval<any>> {
   pure<A>(a: A): Eval<A> {
     return Eval.now(a)
   }
@@ -276,22 +276,6 @@ export class EvalInstances implements MonadError<Eval<any>, Throwable> {
     return Eval.unit()
   }
 
-  raise<A>(e: Throwable): Eval<A> {
-    return Eval.raise(e)
-  }
-
-  attempt<A>(fa: EvalK<A>): Eval<Either<Throwable, A>> {
-    return (fa as Eval<A>).attempt() as any
-  }
-
-  recoverWith<A>(fa: EvalK<A>, f: (e: Throwable) => EvalK<A>): Eval<A> {
-    return (fa as Eval<A>).recoverWith(f as ((e: Throwable) => Eval<A>))
-  }
-
-  recover<A>(fa: EvalK<A>, f: (e: Throwable) => A): Eval<A> {
-    return (fa as Eval<A>).recover(f as ((e: Throwable) => A))
-  }
-
   // Mixed-in
   map2: <A, B, Z>(fa: EvalK<A>, fb: EvalK<B>, f: (a: A, b: B) => Z) => Eval<Z>
   product: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => EvalK<[A, B]>
@@ -305,9 +289,9 @@ export class EvalInstances implements MonadError<Eval<any>, Throwable> {
 }
 
 // Mixins the default implementations
-applyMixins(EvalInstances, [MonadError])
+applyMixins(EvalInstances, [Monad])
 // Registering `EvalInstances` as global instances for `Eval`
-registerTypeClassInstance(MonadError)(Eval, EvalInstances.global)
+registerTypeClassInstance(Monad)(Eval, EvalInstances.global)
 
 /**
  * Alias used for encoding higher-kinded types when implementing

--- a/packages/funfix-types/src/monad.ts
+++ b/packages/funfix-types/src/monad.ts
@@ -909,9 +909,9 @@ applyMixins(MonadErrorLaws, [MonadLaws, ApplicativeErrorLaws])
  * in case there's no such association.
  *
  * ```typescript
- * import { Eval, MonadError, monadErrorOf } from "funfix"
+ * import { IO, MonadError, monadErrorOf } from "funfix"
  *
- * const F: MonadError<Option<any>> = monadErrorOf(Eval)
+ * const F: MonadError<IO<any>> = monadErrorOf(IO)
  * ```
  */
 export const monadErrorOf: <F, E>(c: Constructor<F>) => MonadError<F, E> =

--- a/packages/funfix-types/test/flow/eval.test.js.flow
+++ b/packages/funfix-types/test/flow/eval.test.js.flow
@@ -20,14 +20,10 @@
 import type { Throwable } from "funfix-core"
 import { Eval } from "funfix-effect"
 import {
-  MonadError,
-  monadErrorOf,
   Monad,
   monadOf,
   FlatMap,
   flatMapOf,
-  ApplicativeError,
-  applicativeErrorOf,
   Applicative,
   applicativeOf,
   Apply,
@@ -49,11 +45,5 @@ const applicative2: Applicative<Eval<any>> = EvalInstances.global
 const flatMap1: FlatMap<Eval<any>> = flatMapOf(Eval)
 const flatMap2: FlatMap<Eval<any>> = EvalInstances.global
 
-const apErr1: ApplicativeError<Eval<any>, any> = applicativeErrorOf(Eval)
-const apErr2: ApplicativeError<Eval<any>, Throwable> = EvalInstances.global
-
 const monad1: Monad<Eval<any>> = monadOf(Eval)
 const monad2: Monad<Eval<any>> = EvalInstances.global
-
-const monadErr1: MonadError<Eval<any>, any> = monadErrorOf(Eval)
-const monadErr2: MonadError<Eval<any>, Throwable> = EvalInstances.global

--- a/packages/funfix-types/test/flow/monadError.test.js.flow
+++ b/packages/funfix-types/test/flow/monadError.test.js.flow
@@ -17,9 +17,9 @@
 
 /* @flow */
 
-import type { EvalK, TypeClass } from "../../src/"
+import type { IOK, TypeClass } from "../../src/"
 import { Either, applyMixins } from "funfix-core"
-import { Eval } from "funfix-effect"
+import { IO } from "funfix-effect"
 import {
   Equiv,
   MonadError,
@@ -41,60 +41,60 @@ const typeId: string = MonadError._funTypeId
 const supertypes: string[] = MonadError._funSupertypeIds
 const tc: TypeClass<MonadError<any, any>> = MonadError
 
-const F: MonadError<Eval<any>, any> = monadErrorOf(Eval)
-const apError: ApplicativeError<Eval<any>, any> = F
-const applicative: Applicative<Eval<any>> = F
-const apply: Apply<Eval<any>> = F
-const functor: Functor<Eval<any>> = F
+const F: MonadError<IO<any>, any> = monadErrorOf(IO)
+const apError: ApplicativeError<IO<any>, any> = F
+const applicative: Applicative<IO<any>> = F
+const apply: Apply<IO<any>> = F
+const functor: Functor<IO<any>> = F
 
-const laws1: MonadErrorLaws<Eval<any>, any> = monadErrorLawsOf(F)
-const laws2: ApplicativeErrorLaws<Eval<any>, any> = laws1
-const laws3: ApplicativeLaws<Eval<any>> = laws1
-const laws4: ApplyLaws<Eval<any>> = laws1
-const laws5: FunctorLaws<Eval<any>> = laws1
+const laws1: MonadErrorLaws<IO<any>, any> = monadErrorLawsOf(F)
+const laws2: ApplicativeErrorLaws<IO<any>, any> = laws1
+const laws3: ApplicativeLaws<IO<any>> = laws1
+const laws4: ApplyLaws<IO<any>> = laws1
+const laws5: FunctorLaws<IO<any>> = laws1
 
 // $ExpectError
 const err5: MonadErrorLaws<string> = monadErrorLawsOf(F)
 
-class MonadErrorLawsForEval implements MonadErrorLaws<Eval<any>, any> {
-  +F: MonadError<Eval<any>, any> = monadErrorOf(Eval);
+class MonadErrorLawsForIO implements MonadErrorLaws<IO<any>, any> {
+  +F: MonadError<IO<any>, any> = monadErrorOf(IO);
 
   // Functor
-  covariantIdentity: <A>(fa: EvalK<A>) => Equiv<EvalK<A>>;
-  covariantComposition: <A, B, C>(fa: EvalK<A>, f: (a: A) => B, g: (b: B) => C) => Equiv<EvalK<C>>;
+  covariantIdentity: <A>(fa: IOK<A>) => Equiv<IOK<A>>;
+  covariantComposition: <A, B, C>(fa: IOK<A>, f: (a: A) => B, g: (b: B) => C) => Equiv<IOK<C>>;
   // Apply
-  applyComposition: <A, B, C>(fa: EvalK<A>, fab: EvalK<(a: A) => B>, fbc: EvalK<(b: B) => C>) => Equiv<EvalK<C>>;
-  applyProductConsistency: <A, B>(fa: EvalK<A>, f: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
-  applyMap2Consistency: <A, B>(fa: EvalK<A>, f: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
+  applyComposition: <A, B, C>(fa: IOK<A>, fab: IOK<(a: A) => B>, fbc: IOK<(b: B) => C>) => Equiv<IOK<C>>;
+  applyProductConsistency: <A, B>(fa: IOK<A>, f: IOK<(a: A) => B>) => Equiv<IOK<B>>;
+  applyMap2Consistency: <A, B>(fa: IOK<A>, f: IOK<(a: A) => B>) => Equiv<IOK<B>>;
   // FlatMap
-  flatMapAssociativity: <A, B, C>(fa: EvalK<A>, f: (a: A) => EvalK<B>, g: (b: B) => EvalK<C>) => Equiv<EvalK<C>>;
-  flatMapConsistentApply: <A, B>(fa: EvalK<A>, fab: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
-  followedByConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<B>>;
-  followedByLConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<B>>;
-  forEffectConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<A>>;
-  forEffectLConsistency: <A, B>(fa: EvalK<A>, fb: EvalK<B>) => Equiv<EvalK<A>>;
-  tailRecMConsistentFlatMap: <A>(a: A, f: (a: A) => EvalK<A>) => Equiv<EvalK<A>>;
+  flatMapAssociativity: <A, B, C>(fa: IOK<A>, f: (a: A) => IOK<B>, g: (b: B) => IOK<C>) => Equiv<IOK<C>>;
+  flatMapConsistentApply: <A, B>(fa: IOK<A>, fab: IOK<(a: A) => B>) => Equiv<IOK<B>>;
+  followedByConsistency: <A, B>(fa: IOK<A>, fb: IOK<B>) => Equiv<IOK<B>>;
+  followedByLConsistency: <A, B>(fa: IOK<A>, fb: IOK<B>) => Equiv<IOK<B>>;
+  forEffectConsistency: <A, B>(fa: IOK<A>, fb: IOK<B>) => Equiv<IOK<A>>;
+  forEffectLConsistency: <A, B>(fa: IOK<A>, fb: IOK<B>) => Equiv<IOK<A>>;
+  tailRecMConsistentFlatMap: <A>(a: A, f: (a: A) => IOK<A>) => Equiv<IOK<A>>;
   // Applicative
-  applicativeIdentity: <A>(fa: EvalK<A>) => Equiv<EvalK<A>>;
-  applicativeHomomorphism: <A, B>(a: A, f: (a: A) => B) => Equiv<EvalK<B>>;
-  applicativeInterchange: <A, B>(a: A, ff: EvalK<(a: A) => B>) => Equiv<EvalK<B>>;
-  applicativeMap: <A, B>(fa: EvalK<A>, f: (a: A) => B) => Equiv<EvalK<B>>;
-  applicativeComposition: <A, B, C>(fa: EvalK<A>, fab: EvalK<(a: A) => B>, fbc: EvalK<(b: B) => C>) => Equiv<EvalK<C>>;
-  applicativeUnit: <A>(a: A) => Equiv<EvalK<A>>;
+  applicativeIdentity: <A>(fa: IOK<A>) => Equiv<IOK<A>>;
+  applicativeHomomorphism: <A, B>(a: A, f: (a: A) => B) => Equiv<IOK<B>>;
+  applicativeInterchange: <A, B>(a: A, ff: IOK<(a: A) => B>) => Equiv<IOK<B>>;
+  applicativeMap: <A, B>(fa: IOK<A>, f: (a: A) => B) => Equiv<IOK<B>>;
+  applicativeComposition: <A, B, C>(fa: IOK<A>, fab: IOK<(a: A) => B>, fbc: IOK<(b: B) => C>) => Equiv<IOK<C>>;
+  applicativeUnit: <A>(a: A) => Equiv<IOK<A>>;
   // Monad
-  monadLeftIdentity: <A, B>(a: A, f: (a: A) => EvalK<B>) => Equiv<EvalK<B>>;
-  monadRightIdentity: <A, B>(fa: EvalK<A>) => Equiv<EvalK<A>>;
-  mapFlatMapCoherence: <A, B>(fa: EvalK<A>, f: (a: A) => B) => Equiv<EvalK<B>>;
-  tailRecMStackSafety: () => Equiv<EvalK<number>>;
+  monadLeftIdentity: <A, B>(a: A, f: (a: A) => IOK<B>) => Equiv<IOK<B>>;
+  monadRightIdentity: <A, B>(fa: IOK<A>) => Equiv<IOK<A>>;
+  mapFlatMapCoherence: <A, B>(fa: IOK<A>, f: (a: A) => B) => Equiv<IOK<B>>;
+  tailRecMStackSafety: () => Equiv<IOK<number>>;
   // ApplicativeError
-  monadErrorRecoverWith: <A>(e: any, f: (e: any) => EvalK<A>) => Equiv<EvalK<A>>;
-  monadErrorRecover: <A>(e: any, f: (e: any) => A) => Equiv<EvalK<A>>;
-  recoverWithPure: <A>(a: A, f: (e: any) => EvalK<A>) => Equiv<EvalK<A>>;
-  recoverPure: <A>(a: A, f: (e: any) => A) => Equiv<EvalK<A>>;
-  raiseErrorAttempt: (e: any) => Equiv<EvalK<Either<any, void>>>;
-  pureAttempt: <A>(a: A) => Equiv<EvalK<Either<any, A>>>;
+  monadErrorRecoverWith: <A>(e: any, f: (e: any) => IOK<A>) => Equiv<IOK<A>>;
+  monadErrorRecover: <A>(e: any, f: (e: any) => A) => Equiv<IOK<A>>;
+  recoverWithPure: <A>(a: A, f: (e: any) => IOK<A>) => Equiv<IOK<A>>;
+  recoverPure: <A>(a: A, f: (e: any) => A) => Equiv<IOK<A>>;
+  raiseErrorAttempt: (e: any) => Equiv<IOK<Either<any, void>>>;
+  pureAttempt: <A>(a: A) => Equiv<IOK<Either<any, A>>>;
   // MonadError
-  monadErrorLeftZero: <A, B>(e: any, f: (a: A) => EvalK<B>) => Equiv<EvalK<B>>
+  monadErrorLeftZero: <A, B>(e: any, f: (a: A) => IOK<B>) => Equiv<IOK<B>>
 }
 
-applyMixins(MonadErrorLawsForEval, [MonadErrorLaws])
+applyMixins(MonadErrorLawsForIO, [MonadErrorLaws])

--- a/packages/funfix-types/test/ts/eval.test.ts
+++ b/packages/funfix-types/test/ts/eval.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { is } from "funfix-core"
 import { Eval } from "funfix-effect"
 import * as jv from "jsverify"
 import * as laws from "./laws"
@@ -25,9 +26,9 @@ describe("Eval obeys type class laws", () => {
   const eq =
     new (class extends Eq<Eval<any>> {
       eqv(lh: Eval<any>, rh: Eval<any>): boolean {
-        return lh.run().equals(rh.run())
+        return is(lh.get(), rh.get())
       }
     })()
 
-  laws.testMonadError(Eval, jv.number, inst.arbEval, jv.string, eq)
+  laws.testMonad(Eval, jv.number, inst.arbEval, eq)
 })

--- a/packages/funfix-types/test/ts/instances.ts
+++ b/packages/funfix-types/test/ts/instances.ts
@@ -75,16 +75,14 @@ export const arbAny: jv.Arbitrary<any> =
 export const arbEval: jv.Arbitrary<Eval<number>> =
   jv.pair(jv.number, jv.number).smap(
     v => {
-      switch (v[0] % 6) {
+      switch (v[0] % 5) {
         case 0:
           return Eval.now(v[1])
         case 1:
-          return Eval.raise(v[1])
-        case 2:
           return Eval.always(() => v[1])
-        case 3:
+        case 2:
           return Eval.once(() => v[1])
-        case 4:
+        case 3:
           return Eval.suspend(() => Eval.now(v[1]))
         default:
           return Eval.now(0).flatMap(_ => Eval.now(v[1]))

--- a/packages/funfix/test/flow/import.test.js.flow
+++ b/packages/funfix/test/flow/import.test.js.flow
@@ -17,7 +17,7 @@
 
 /* @flow */
 
-import { Option, Future, Eval, Monad, monadOf } from "../../src/"
+import { Option, Future, Eval, IO, Monad, monadOf } from "../../src/"
 
 const opt: Option<number> = Option.of(10)
 const f: Future<string> = Future.of(() => "Hello!")

--- a/packages/funfix/test/ts/import.test.ts
+++ b/packages/funfix/test/ts/import.test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as assert from "assert"
-import { Option, Future, is, Some, Success, Eval, Monad, monadErrorOf } from "../../src"
+import { Option, Future, is, Some, Success, Eval, Monad, monadOf } from "../../src"
 
 function assertEquals<A>(lh: A, rh: A): void {
   assert.ok(is(lh, rh), `${lh} != ${rh}`)
@@ -36,7 +36,7 @@ describe("funfix module sanity test", () => {
   })
 
   it("works for Monad", () => {
-    const m = monadErrorOf(Eval)
+    const m = monadOf(Eval)
     const v = m.flatMap(Eval.of(() => 1), a => Eval.of(() => a + 1)) as Eval<number>
     assertEquals(v.get(), 2)
   })


### PR DESCRIPTION
BREAKING CHANGE: Removed `.attempt`, `.recover(With)`, `.transform(With)`, `Eval.raise(e)`, `EvalInstances` implements just `Monad`.

This is because `Eval` should be a `Comonad` and that's incompatible with `MonadError`.