### PR TITLE
feat(core): remove left() and right() for Either, add Try.raise

### DIFF
--- a/packages/funfix-core/src/disjunctions.js.flow
+++ b/packages/funfix-core/src/disjunctions.js.flow
@@ -25,9 +25,7 @@ declare export class Either<+L, +R> {
   getOrElseL<RR>(thunk: () => RR): R | RR;
 
   isLeft(): boolean;
-  left(): Either<L, empty>;
   isRight(): boolean;
-  right(): Either<empty, R>;
   contains(elem: R): boolean;
   exists(p: (r: R) => boolean): boolean;
   filterOrElse<LL>(p: (r: R) => boolean, zero: () => LL): Either<L | LL, R>;
@@ -160,7 +158,8 @@ declare export class Try<+A> {
   static pure<A>(value: A): Try<A>;
   static unit(): Try<void>;
   static success<A>(value: A): Try<A>;
-  static failure<A>(e: Throwable): Try<A>;
+  static failure(e: Throwable): Try<empty>;
+  static raise(e: Throwable): Try<empty>;
 
   static map2<A1,A2,R>(
     fa1: Try<A1>, fa2: Try<A2>,

--- a/packages/funfix-core/src/disjunctions.ts
+++ b/packages/funfix-core/src/disjunctions.ts
@@ -72,22 +72,6 @@ export class Either<L, R> implements std.IEquals<Either<L, R>> {
   isLeft(): boolean { return !this._isRight }
 
   /**
-   * If the source is a `left` value, then returns it unchanged
-   * and casted as a `Left`, otherwise throw exception.
-   *
-   * WARNING!
-   *
-   * This function is partial, the reference must be a `Left,
-   * otherwise a runtime exception will get thrown. Use with care.
-   *
-   * @throws NoSuchElementError
-   */
-  left(): Either<L, never> {
-    if (!this._isRight) return this as any
-    throw new NoSuchElementError("either.left")
-  }
-
-  /**
    * Returns `true` if this is a `right`, `false` otherwise.
    *
    * ```typescript
@@ -96,22 +80,6 @@ export class Either<L, R> implements std.IEquals<Either<L, R>> {
    * ```
    */
   isRight(): boolean { return this._isRight }
-
-  /**
-   * If the source is a `right` value, then returns it unchanged
-   * and casted as a `Right`, otherwise throw exception.
-   *
-   * WARNING!
-   *
-   * This function is partial, the reference must be a `Right,
-   * otherwise a runtime exception will get thrown. Use with care.
-   *
-   * @throws NoSuchElementError
-   */
-  right(): Either<never, R> {
-    if (this._isRight) return this as any
-    throw new NoSuchElementError("either.right")
-  }
 
   /**
    * Returns true if this is a Right and its value is equal to `elem`
@@ -172,8 +140,8 @@ export class Either<L, R> implements std.IEquals<Either<L, R>> {
    */
   filterOrElse(p: (r: R) => boolean, zero: () => L): Either<L, R> {
     return this._isRight
-      ? (p(this._rightRef) ? this.right() : Left(zero()))
-      : this.left()
+      ? (p(this._rightRef) ? (this as any) : Left(zero()))
+      : (this as any)
   }
 
   /**
@@ -183,7 +151,7 @@ export class Either<L, R> implements std.IEquals<Either<L, R>> {
    * It can be used to *chain* multiple `Either` references.
    */
   flatMap<S>(f: (r: R) => Either<L, S>): Either<L, S> {
-    return this._isRight ? f(this._rightRef) : this.left()
+    return this._isRight ? f(this._rightRef) : (this as any)
   }
 
   /**
@@ -279,7 +247,7 @@ export class Either<L, R> implements std.IEquals<Either<L, R>> {
   map<C>(f: (r: R) => C): Either<L, C> {
     return this._isRight
       ? Right(f(this._rightRef))
-      : this.left()
+      : (this as any)
   }
 
   /**
@@ -1474,7 +1442,15 @@ export class Try<A> implements std.IEquals<Try<A>> {
    * Returns a [[Try]] reference that represents a failure
    * (i.e. an exception wrapped in [[Failure]]).
    */
-  static failure<A>(e: Throwable): Try<A> {
+  static failure<A = never>(e: Throwable): Try<A> {
+    return Failure(e)
+  }
+
+  /**
+   * Alias for {@link Try.failure} and {@link Failure},
+   * wrapping any throwable into a `Try` value.
+   */
+  static raise<A = never>(e: Throwable): Try<A> {
     return Failure(e)
   }
 

--- a/packages/funfix-core/test/flow/try.test.js.flow
+++ b/packages/funfix-core/test/flow/try.test.js.flow
@@ -48,3 +48,6 @@ const r26: Try<Animal> = dogTry.orElse(Success(new Cat()))
 const r27: Try<Animal> = dogTry.orElseL(() => Success(new Cat()))
 const r28: Try<Object> = dogTry.orElse(Success(new Human()))
 const r29: Try<Object> = dogTry.orElseL(() => Success(new Human()))
+
+const fail1: Try<number> = Try.raise("error")
+const fail2: Try<number> = Try.failure("error")

--- a/packages/funfix-core/test/ts/either.test.ts
+++ b/packages/funfix-core/test/ts/either.test.ts
@@ -26,24 +26,6 @@ describe("Either", () => {
       inst.arbEither,
       e => e.isRight() === !e.isLeft()
     )
-
-    jv.property("isRight => right() does not throw",
-      inst.arbEither,
-      e => e.isLeft() || e.right().isRight()
-    )
-
-    jv.property("isLeft => left() does not throw",
-      inst.arbEither,
-      e => e.isRight() || e.left().isLeft()
-    )
-
-    it("right.left() throws", () => {
-      assert.throws(() => Either.right(1).left())
-    })
-
-    it("left.right() throws", () => {
-      assert.throws(() => Either.left(1).right())
-    })
   })
 
   describe("Either #get", () => {

--- a/packages/funfix-core/test/ts/instances.ts
+++ b/packages/funfix-core/test/ts/instances.ts
@@ -21,7 +21,7 @@ import {
   Option, Some,
   Either, Left, Right,
   Try, Failure, Success,
-  DummyError, is
+  DummyError
 } from "../../src/"
 
 export const arbAnyPrimitive: jv.Arbitrary<any> =
@@ -37,7 +37,7 @@ export const arbOptNonempty: jv.Arbitrary<Option<number>> =
 export const arbEither: jv.Arbitrary<Either<number, number>> =
   jv.number.smap(
     i => i % 4 < 3 ? Right(i) : Left(i),
-    (fa: Either<number, number>) => fa.isRight() ? fa.get() : fa.left().get()
+    (fa: Either<number, number>) => fa.isRight() ? fa.get() : fa.swap().get()
   )
 
 export const arbSuccess: jv.Arbitrary<Try<number>> =

--- a/packages/funfix-core/test/ts/try.test.ts
+++ b/packages/funfix-core/test/ts/try.test.ts
@@ -468,13 +468,18 @@ describe("Try map2, map3, map4, map5, map6", () => {
   })
 })
 
-describe("Try.unit", () => {
-  it("returns the same reference and works", () => {
+describe("Try misc builders", () => {
+  it("unit returns the same reference and works", () => {
     const e1 = Try.unit()
     const e2 = Try.unit()
 
     assert.equal(e1, e2)
     assert.equal(e1.get(), undefined)
+  })
+
+  it("raise is an alias for failure", () => {
+    assert.equal(Try.raise("error"), Try.failure("error"))
+    assert.notEqual(Try.raise("yes"), Try.failure("no"))
   })
 })
 

--- a/packages/funfix-types/src/monad.ts
+++ b/packages/funfix-types/src/monad.ts
@@ -92,7 +92,7 @@ import {
  *       const box = f(cursor) as Box<Either<A, B>>
  *       const v = box.value
  *       if (v.isRight()) return new Box(v.get())
- *       cursor = v.left().get()
+ *       cursor = v.swap().get()
  *     }
  *   }
  *
@@ -442,7 +442,7 @@ export function flatMapLawsOf<F>(instance: FlatMap<F>): FlatMapLaws<F> {
  *       const box = f(cursor) as Box<Either<A, B>>
  *       const v = box.value
  *       if (v.isRight()) return new Box(v.get())
- *       cursor = v.left().get()
+ *       cursor = v.swap().get()
  *     }
  *   }
  *

--- a/packages/funfix-types/test/ts/instances.ts
+++ b/packages/funfix-types/test/ts/instances.ts
@@ -53,7 +53,7 @@ export const arbOptNonempty: jv.Arbitrary<Option<number>> =
 export const arbEither: jv.Arbitrary<Either<number, number>> =
   jv.number.smap(
     i => i % 4 < 3 ? Right(i) : Left(i),
-    (fa: Either<number, number>) => fa.isRight() ? fa.get() : fa.left().get()
+    (fa: Either<number, number>) => fa.isRight() ? fa.get() : fa.swap().get()
   )
 
 export const arbSuccess: jv.Arbitrary<Try<number>> =


### PR DESCRIPTION
BREAKING CHANGE: Removal of left() and right() breaks compatibility for Either.

The reason is that `left()` and `right()` are 2 confusing and partial functions that aren't useful, being boobytraps for beginners.

Also added `Try.raise`, to be in sync with all other `MonadError` types.