### PR TITLE
chore(package): update TypeScript to 2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tslint-config-standard": "^6.0.1",
     "tslint-eslint-rules": "^4.1.1",
     "typedoc": "^0.8.0",
-    "typescript": "rc",
+    "typescript": "~2.5.2",
     "validate-commit-msg": "^2.14.0"
   },
   "config": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,9 +3276,9 @@ typescript@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
-typescript@rc:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
+typescript@~2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
 
 typify-parser@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
We were on the "release candidate" (rc), or 2.5.1