### PR TITLE
Fix npm install "--saFe" option typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ universally available, belonging into a standard library.
 For an à la carte install:
 
 ```
-npm install --safe funfix-core
+npm install --save funfix-core
 ```
 
 Exposes types for expressing disjunctions:
@@ -112,7 +112,7 @@ building higher level concurrency tools.
 For an à la carte install:
 
 ```
-npm install --safe funfix-exec
+npm install --save funfix-exec
 ```
 
 Scheduling tasks for asynchronous execution:
@@ -151,7 +151,7 @@ Defines monadic data types for controlling laziness, asynchrony and side effects
 For an à la carte install:
 
 ```
-npm install --safe funfix-effect
+npm install --save funfix-effect
 ```
 
 The exposed data types:
@@ -171,7 +171,7 @@ by [Typelevel Cats](https://typelevel.org/cats/).
 For an à la carte install:
 
 ```
-npm install --safe funfix-types
+npm install --save funfix-types
 ```
 
 [Type classes](https://en.wikipedia.org/wiki/Type_class) inspired by


### PR DESCRIPTION
`--safe` option looks like a typo, as far as I know.

```
$ npm --version
3.10.10

$ npm install --help

npm install (with no args, in package dir)
npm install [<@scope>/]<pkg>
npm install [<@scope>/]<pkg>@<tag>
npm install [<@scope>/]<pkg>@<version>
npm install [<@scope>/]<pkg>@<version range>
npm install <folder>
npm install <tarball file>
npm install <tarball url>
npm install <git:// url>
npm install <github username>/<github project>

aliases: i, isntall
common options: [--save|--save-dev|--save-optional] [--save-exact]
```

Also `--save` option is replaced by `--save-prod` in npm version 5 (maybe earlier) which is the default.

```
$ npm --version
5.4.0

$ npm install --help

npm install (with no args, in package dir)
npm install [<@scope>/]<pkg>
npm install [<@scope>/]<pkg>@<tag>
npm install [<@scope>/]<pkg>@<version>
npm install [<@scope>/]<pkg>@<version range>
npm install <folder>
npm install <tarball file>
npm install <tarball url>
npm install <git:// url>
npm install <github username>/<github project>

aliases: i, isntall, add
common options: [--save-prod|--save-dev|--save-optional] [--save-exact] [--no-save]
```
