### PR TITLE
fix(effect): remove extra type param from IO.run

### DIFF
--- a/packages/funfix-effect/src/io.js.flow
+++ b/packages/funfix-effect/src/io.js.flow
@@ -22,8 +22,8 @@ import { Either, Try, Option } from "funfix-core";
 import { ICancelable, StackedCancelable, Scheduler, Future, ExecutionModel, Duration } from "funfix-exec";
 
 declare export class IO<+A> {
-  run<A>(ec?: Scheduler): Future<A>;
-  runOnComplete<A>(cb: (result: Try<A>) => void, ec?: Scheduler): ICancelable;
+  run(ec?: Scheduler): Future<A>;
+  runOnComplete(cb: (result: Try<A>) => void, ec?: Scheduler): ICancelable;
 
   attempt(): IO<Either<Throwable, A>>;
   asyncBoundary(ec?: Scheduler): IO<A>;

--- a/packages/funfix-effect/src/io.ts
+++ b/packages/funfix-effect/src/io.ts
@@ -387,7 +387,7 @@ export class IO<A> {
    * @return a `Future` that will eventually complete with the
    *         result produced by this `IO` on evaluation
    */
-  run<A>(ec: Scheduler = Scheduler.global.get()): Future<A> {
+  run(ec: Scheduler = Scheduler.global.get()): Future<A> {
     return taskToFutureRunLoop(this, ec)
   }
 
@@ -457,7 +457,7 @@ export class IO<A> {
    *         the running computation, assuming that the implementation
    *         of the source `IO` can be cancelled
    */
-  runOnComplete<A>(
+  runOnComplete(
     cb: (result: Try<A>) => void,
     ec: Scheduler = Scheduler.global.get()): ICancelable {
 


### PR DESCRIPTION
Fixes #64 