### PR TITLE
Add support for user-defined type guards to filter predicate

### DIFF
--- a/packages/funfix-core/src/disjunctions.ts
+++ b/packages/funfix-core/src/disjunctions.ts
@@ -701,6 +701,8 @@ export class Option<A> implements std.IEquals<Option<A>> {
    * @return a new option instance containing the value of the
    *         source filtered with the given predicate
    */
+  filter<B extends A>(p: (a: A) => a is B): Option<B>
+  filter(p: (a: A) => boolean): Option<A>
   filter(p: (a: A) => boolean): Option<A> {
     if (this._isEmpty || !p(this._ref)) return None
     else return this
@@ -1243,6 +1245,8 @@ export class Try<A> implements std.IEquals<Try<A>> {
    *
    * @throws NoSuchElementError in case the predicate doesn't hold
    */
+  filter<B extends A>(p: (a: A) => a is B): Try<B>
+  filter(p: (a: A) => boolean): Try<A>
   filter(p: (a: A) => boolean): Try<A> {
     if (!this._isSuccess) return this
     try {


### PR DESCRIPTION
This enables the following:

``` ts
const isNumber = (x: string | number): x is number => true
Option.of(1 as string | number)
  .filter(isNumber)
  .map(x => {
    const y: number = x
  })
```

https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards

- I'm not sure where to add the tests for this, seeing as it would be testing the type level behaviour. IxJS does it like so: https://github.com/ReactiveX/IxJS/blob/8c451387cc228d9506416936c9dda5983d5ee2df/spec/iterable-operators/filter-spec.ts#L36
- Is this possible in Flow? If so, we should update the Flow types to correspond.