### PR TITLE
#113: Targeting ES5 environments with module file while maintaining import/export statements for tree shaking

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -40,9 +40,9 @@
     "build": "tsc && npm run rollup && npm run doc",
     "start": "node ../../node_modules/.bin/tsc-watch --onSuccess 'npm run rollup'",
 
-    "test": "mocha --opts mocha.opts",
-    "test:watch": "mocha --opts mocha.opts --watch",
-    "test:prod": "npm run lint && nyc mocha --opts mocha.opts --reporter dot",
+    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --opts mocha.opts",
+    "test:watch": "npm run test -- --watch",
+    "test:prod": "npm run lint && nyc npm run test -- --reporter dot",
 
     "rollup": "rollup -c && npm run fix-modules && npm run fix-types",
     "fix-modules": "node ../../scripts/fix-es5.js dist/es5.js",

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+      "module": "es2015",
       "moduleResolution": "node",
-      "target": "es2015",
+      "target": "es5",
       "lib": ["es2015", "dom.iterable"],
       "strict": true,
       "sourceMap": true,

--- a/packages/funfix-core/package.json
+++ b/packages/funfix-core/package.json
@@ -13,9 +13,9 @@
     "prebuild": "npm run clean",
     "build": "tsc && npm run rollup && npm run doc",
     "start": "node ../../node_modules/.bin/tsc-watch --onSuccess 'npm run rollup'",
-    "test": "mocha --opts mocha.opts",
-    "test:watch": "mocha --opts mocha.opts --watch",
-    "test:prod": "npm run lint && nyc mocha --opts mocha.opts --reporter dot",
+    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --opts mocha.opts",
+    "test:watch": "npm run test -- --watch",
+    "test:prod": "npm run lint && nyc npm run test -- --reporter dot",
     "rollup": "rollup -c && npm run fix-modules && npm run fix-types",
     "fix-modules": "node ../../scripts/fix-es5.js dist/es5.js",
     "fix-types": "../../scripts/fix-types.js ."

--- a/packages/funfix-effect/package.json
+++ b/packages/funfix-effect/package.json
@@ -13,9 +13,9 @@
     "prebuild": "npm run clean",
     "build": "tsc && npm run rollup && npm run doc",
     "start": "node ../../node_modules/.bin/tsc-watch --onSuccess 'npm run rollup'",
-    "test": "mocha --opts mocha.opts",
-    "test:watch": "mocha --opts mocha.opts --watch",
-    "test:prod": "npm run lint && nyc mocha --opts mocha.opts --reporter dot",
+    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --opts mocha.opts",
+    "test:watch": "npm run test -- --watch",
+    "test:prod": "npm run lint && nyc npm run test -- --reporter dot",
     "rollup": "rollup -c && npm run fix-modules && npm run fix-types",
     "fix-modules": "node ../../scripts/fix-es5.js dist/es5.js",
     "fix-types": "../../scripts/fix-types.js ."

--- a/packages/funfix-exec/package.json
+++ b/packages/funfix-exec/package.json
@@ -13,9 +13,9 @@
     "prebuild": "npm run clean",
     "build": "tsc && npm run rollup && npm run doc",
     "start": "node ../../node_modules/.bin/tsc-watch --onSuccess 'npm run rollup'",
-    "test": "mocha --opts mocha.opts",
-    "test:watch": "mocha --opts mocha.opts --watch",
-    "test:prod": "npm run lint && nyc mocha --opts mocha.opts --reporter dot",
+    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --opts mocha.opts",
+    "test:watch": "npm run test -- --watch",
+    "test:prod": "npm run lint && nyc npm run test -- --reporter dot",
     "rollup": "rollup -c && npm run fix-modules && npm run fix-types",
     "fix-modules": "node ../../scripts/fix-es5.js dist/es5.js",
     "fix-types": "../../scripts/fix-types.js ."

--- a/packages/funfix/package.json
+++ b/packages/funfix/package.json
@@ -41,9 +41,9 @@
     "prebuild": "npm run clean",
     "build": "tsc && npm run rollup && npm run doc",
     "start": "node ../../node_modules/.bin/tsc-watch --onSuccess 'npm run rollup'",
-    "test": "mocha --opts mocha.opts",
-    "test:watch": "mocha --opts mocha.opts --watch",
-    "test:prod": "npm run lint && nyc mocha --opts mocha.opts --reporter dot",
+    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --opts mocha.opts",
+    "test:watch": "npm run test -- --watch",
+    "test:prod": "npm run lint && nyc npm run test -- --reporter dot",
     "rollup": "rollup -c && npm run fix-modules && npm run fix-types",
     "fix-modules": "node ../../scripts/fix-es5.js dist/es5.js",
     "fix-types": "../../scripts/fix-types.js ."


### PR DESCRIPTION
This PR updates the Typescript config so that the outputted JS is ES5 compatible, yet maintains import/export statements, as per is intended by the `module` attribute (https://github.com/rollup/rollup/wiki/pkg.module).